### PR TITLE
fix(propagate): do not propagate apikey if config is null

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -121,7 +121,7 @@ public class ApiKeyPolicy {
 
         // 1_ First, search in HTTP headers
         String apiKey = request.headers().getFirst(API_KEY_HEADER);
-        if (apiKeyPolicyConfiguration != null && ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+        if (apiKeyPolicyConfiguration == null || ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
             request.headers().remove(API_KEY_HEADER);
         }
 
@@ -129,7 +129,7 @@ public class ApiKeyPolicy {
             // 2_ If not found, search in query parameters
             apiKey = request.parameters().getFirst(API_KEY_QUERY_PARAMETER);
 
-            if (apiKeyPolicyConfiguration != null && ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+            if (apiKeyPolicyConfiguration == null || ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
                 request.parameters().remove(API_KEY_QUERY_PARAMETER);
             }
         }


### PR DESCRIPTION
fix gravitee-io/issues#1462