### PR TITLE
issue 1719 custom error payloads for the api-key policy 1/3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ hs_err_pid*
 # Idea files
 /.idea/
 /*.iml
+/.classpath
+/.project
+/.settings/

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -18,7 +18,7 @@ Providing the following information will help us to deal quickly with your issue
 
 == Submitting changes
 
-You've submitted an issue to the project and know how to fix it? You can contribute to the project?by https://guides.github.com/activities/forking/[forking the repository] and https://guides.github.com/activities/forking/#making-a-pull-request[submitting your pull requests].
+You've submitted an issue to the project and know how to fix it? You can contribute to the project by https://guides.github.com/activities/forking/[forking the repository] and https://guides.github.com/activities/forking/#making-a-pull-request[submitting your pull requests].
 
 Before you submit your pull request consider the following guidelines:
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>7</version>
+        <version>13-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>14-SNAPSHOT</version>
+        <version>14</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>13</version>
+        <version>14-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>13-SNAPSHOT</version>
+        <version>13</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Description of the ApiKey Gravitee Policy</description>
@@ -34,9 +34,9 @@
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.6.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.11.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.2.0</gravitee-policy-api.version>
-        <gravitee-repository-api.version>1.10.0</gravitee-repository-api.version>
+        <gravitee-repository-api.version>1.18.0</gravitee-repository-api.version>
 
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Description of the ApiKey Gravitee Policy</description>
@@ -30,13 +30,13 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>14</version>
+        <version>15</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.11.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.2.0</gravitee-policy-api.version>
-        <gravitee-repository-api.version>1.18.0</gravitee-repository-api.version>
+        <gravitee-gateway-api.version>1.14.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>
+        <gravitee-repository-api.version>1.24.0</gravitee-repository-api.version>
 
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
@@ -87,14 +87,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Description of the ApiKey Gravitee Policy</description>

--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -121,7 +121,7 @@ public class ApiKeyPolicy {
 
         // 1_ First, search in HTTP headers
         String apiKey = request.headers().getFirst(API_KEY_HEADER);
-        if (! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+        if (apiKeyPolicyConfiguration != null && ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
             request.headers().remove(API_KEY_HEADER);
         }
 
@@ -129,7 +129,7 @@ public class ApiKeyPolicy {
             // 2_ If not found, search in query parameters
             apiKey = request.parameters().getFirst(API_KEY_QUERY_PARAMETER);
 
-            if (! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+            if (apiKeyPolicyConfiguration != null && ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
                 request.parameters().remove(API_KEY_QUERY_PARAMETER);
             }
         }

--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -121,7 +121,7 @@ public class ApiKeyPolicy {
 
         // 1_ First, search in HTTP headers
         String apiKey = request.headers().getFirst(API_KEY_HEADER);
-        if (apiKeyPolicyConfiguration != null && ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+        if (apiKeyPolicyConfiguration == null || ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
             request.headers().remove(API_KEY_HEADER);
         }
 
@@ -129,7 +129,7 @@ public class ApiKeyPolicy {
             // 2_ If not found, search in query parameters
             apiKey = request.parameters().getFirst(API_KEY_QUERY_PARAMETER);
 
-            if (apiKeyPolicyConfiguration != null && ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+            if (apiKeyPolicyConfiguration == null || ! apiKeyPolicyConfiguration.isPropagateApiKey()) {
                 request.parameters().remove(API_KEY_QUERY_PARAMETER);
             }
         }

--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -121,12 +121,17 @@ public class ApiKeyPolicy {
 
         // 1_ First, search in HTTP headers
         String apiKey = request.headers().getFirst(API_KEY_HEADER);
-        request.headers().remove(API_KEY_HEADER);
+        if (! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+            request.headers().remove(API_KEY_HEADER);
+        }
 
         if (apiKey == null || apiKey.isEmpty()) {
             // 2_ If not found, search in query parameters
             apiKey = request.parameters().getFirst(API_KEY_QUERY_PARAMETER);
-            request.parameters().remove(API_KEY_QUERY_PARAMETER);
+
+            if (! apiKeyPolicyConfiguration.isPropagateApiKey()) {
+                request.parameters().remove(API_KEY_QUERY_PARAMETER);
+            }
         }
 
         return apiKey;

--- a/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.policy.apikey.configuration;
 
+import java.util.List;
 import io.gravitee.policy.api.PolicyConfiguration;
 
 /**
@@ -25,11 +26,30 @@ public class ApiKeyPolicyConfiguration implements PolicyConfiguration {
 
     private boolean propagateApiKey = false;
 
+    private List<Response> responses;
+
     public boolean isPropagateApiKey() {
         return propagateApiKey;
     }
 
     public void setPropagateApiKey(boolean propagateApiKey) {
         this.propagateApiKey = propagateApiKey;
+    }
+
+    /**
+     * @return the list of configured responses, may be <code>null</code>.
+     * @since 1.6.3
+     */
+    public List<Response> getResponses() {
+        return this.responses;
+    }
+
+    /**
+     * @param responses
+     *        the responses to set
+     * @since 1.6.3
+     */
+    public void setResponses(final List<Response> responses) {
+        this.responses = responses;
     }
 }

--- a/src/main/java/io/gravitee/policy/apikey/configuration/ErrorType.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ErrorType.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.apikey.configuration;
+
+/**
+ * a type of error to configure a response for.<br/>
+ * erzeugt am 06.12.2018
+ *
+ * @author Oliver Kelling, https://github.com/k-oliver
+ * @since 1.6.3
+ */
+public enum ErrorType {
+
+    /**
+     * no API key was given.
+     *
+     * @since 1.6.3
+     */
+    MISSING,
+
+    /**
+     * API key is wrong, expired or revoked.
+     *
+     * @since 1.6.3
+     */
+    WRONG_EXPIRED_REVOKED
+}

--- a/src/main/java/io/gravitee/policy/apikey/configuration/Response.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/Response.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.apikey.configuration;
+
+/**
+ * a {@link Response} to a failed API key policy check. The {@link Response} can be configured for different content types and {@link ErrorType error types}.<br/>
+ * created 06.12.2018
+ *
+ * @author Oliver Kelling, https://github.com/k-oliver
+ * @since 1.6.3
+ */
+public class Response {
+
+    private String contentType;
+    private ErrorType type;
+    private Integer statusCode;
+    private String content;
+
+    /**
+     * @return the content type to be matched by the <code>Accept</code> header.
+     * @since 1.6.3
+     */
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    /**
+     * @param contentType
+     *        the content type to be matched by the <code>Accept</code> header.
+     * @since 1.6.3
+     */
+    public void setContentType(final String contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+     * @return the type of error.
+     * @since 1.6.3
+     */
+    public ErrorType getType() {
+        return this.type;
+    }
+
+    /**
+     * @param type
+     *        the type of erro to set.
+     * @since 1.6.3
+     */
+    public void setType(final ErrorType type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the HTTP status code to be send.
+     * @since 1.6.3
+     */
+    public Integer getStatusCode() {
+        return this.statusCode;
+    }
+
+    /**
+     * @param statusCode
+     *       the HTTP status code to be send.
+     * @since 1.6.3
+     */
+    public void setStatusCode(final Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * @return the content to be send matching the {@link #getContentType()}.
+     * @since 1.6.3
+     */
+    public String getContent() {
+        return this.content;
+    }
+
+    /**
+     * @param content
+     *        the content to be send matching the {@link #setContentType(String)}.
+     * @since 1.6.3
+     */
+    public void setContent(final String content) {
+        this.content = content;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#hashCode()
+     * @since 1.6.3
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (this.content == null ? 0 : this.content.hashCode());
+        result = prime * result + (this.contentType == null ? 0 : this.contentType.hashCode());
+        result = prime * result + (this.statusCode == null ? 0 : this.statusCode.hashCode());
+        result = prime * result + (this.type == null ? 0 : this.type.hashCode());
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#equals(java.lang.Object)
+     * @since 1.6.3
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Response)) {
+            return false;
+        }
+        final Response other = (Response)obj;
+        if (this.content == null) {
+            if (other.content != null) {
+                return false;
+            }
+        } else if (!this.content.equals(other.content)) {
+            return false;
+        }
+        if (this.contentType == null) {
+            if (other.contentType != null) {
+                return false;
+            }
+        } else if (!this.contentType.equals(other.contentType)) {
+            return false;
+        }
+        if (this.statusCode == null) {
+            if (other.statusCode != null) {
+                return false;
+            }
+        } else if (!this.statusCode.equals(other.statusCode)) {
+            return false;
+        }
+        if (this.type != other.type) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#toString()
+     * @since 1.6.3
+     */
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Response[");
+        if (this.contentType != null) {
+            builder.append("contentType=");
+            builder.append(this.contentType);
+            builder.append(", ");
+        }
+        if (this.type != null) {
+            builder.append("type=");
+            builder.append(this.type);
+            builder.append(", ");
+        }
+        if (this.statusCode != null) {
+            builder.append("statusCode=");
+            builder.append(this.statusCode);
+            builder.append(", ");
+        }
+        if (this.content != null) {
+            builder.append("content=");
+            builder.append(this.content);
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -5,6 +5,46 @@
     "propagateApiKey" : {
       "title": "Propagate API Key to upstream API",
       "type" : "boolean"
+    },
+    "responses" : {
+      "title": "User defined response by content type and error type",
+      "description": "An optional list of responses to be send back to the client if the API key check failed",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "title": "Response",
+        "id" : "urn:jsonschema:io:gravitee:policy:apikey:configuration:Response",
+        "properties" : {
+          "contentType" : {
+            "title": "Content-Type",
+            "description": "The content type send as Accept header (support EL).",
+            "type" : "string"
+          },
+          "type" : {
+            "title": "the type of error to respond to",
+            "description": "the type of error.",
+            "type" : "string",
+            "default": "MISSING",
+      		"enum" : [ "MISSING", "WRONG_EXPIRED_REVOKED" ]
+          },
+          "statusCode": {
+            "title": "HTTP status code",
+            "description": "The HTTP status code to return.",
+            "type" : "integer"
+          },
+          "content" : {
+            "title": "Content",
+            "description": "The content to send back. The content should match the content type (support EL).",
+            "type" : "string"
+          }
+        },
+        "required": [
+          "contentType",
+          "type",
+          "statusCode",
+          "content"
+        ]
+      }
     }
   }
 }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -17,6 +17,7 @@ package io.gravitee.policy.apikey;
 
 
 import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.MediaType;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.ExecutionContext;
@@ -25,6 +26,7 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.apikey.configuration.ErrorType;
 import io.gravitee.reporter.api.http.Metrics;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
@@ -35,7 +37,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
 
 import java.time.Duration;
@@ -160,7 +162,7 @@ public class ApiKeyPolicyTest {
         Instant requestDate = validApiKey.getExpireAt().toInstant().minus(Duration.ofHours(1));
 
         when(request.headers()).thenReturn(headers);
-        when(request.timestamp()).thenReturn(requestDate);
+        when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
         when(apiKeyRepository.findById(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
@@ -190,7 +192,7 @@ public class ApiKeyPolicyTest {
         Instant requestDate = validApiKey.getExpireAt().toInstant().minus(Duration.ofHours(1));
 
         when(request.headers()).thenReturn(headers);
-        when(request.timestamp()).thenReturn(requestDate);
+        when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
         when(apiKeyRepository.findById(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
@@ -245,7 +247,7 @@ public class ApiKeyPolicyTest {
         Instant requestDate = validApiKey.getExpireAt().toInstant().minus(Duration.ofHours(1));
 
         when(request.headers()).thenReturn(headers);
-        when(request.timestamp()).thenReturn(requestDate);
+        when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
         when(apiKeyRepository.findById(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
@@ -272,7 +274,7 @@ public class ApiKeyPolicyTest {
         Instant requestDate = validApiKey.getExpireAt().toInstant().plus(Duration.ofHours(1));
 
         when(request.headers()).thenReturn(headers);
-        when(request.timestamp()).thenReturn(requestDate);
+        when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
         when(apiKeyRepository.findById(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
@@ -336,8 +338,6 @@ public class ApiKeyPolicyTest {
 
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
-        when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findById(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
         when(apiKeyRepository.findById(notExistingApiKey)).thenReturn(Optional.empty());
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
@@ -443,5 +443,87 @@ public class ApiKeyPolicyTest {
         Assert.assertTrue(request.headers().containsKey(X_GRAVITEE_API_KEY));
         verify(apiKeyRepository).findById(API_KEY_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
+    }
+
+    /**
+     * test case for a configured response where the request matches a configured response.
+     *
+     * @throws TechnicalException
+     * @since 1.6.3
+     */
+    @Test
+    public void testResponseConfiguration() throws TechnicalException {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setAll(new HashMap<String, String>() {
+
+            {
+                this.put(X_GRAVITEE_API_KEY, ApiKeyPolicyTest.API_KEY_HEADER_VALUE);
+                this.put("Accept", MediaType.APPLICATION_JSON);
+            }
+        });
+
+        final ApiKey invalidApiKey = new ApiKey();
+        invalidApiKey.setRevoked(true);
+        invalidApiKey.setPlan(ApiKeyPolicyTest.PLAN_NAME_HEADER_VALUE);
+
+        when(this.request.headers()).thenReturn(headers);
+        when(this.executionContext.getComponent(ApiKeyRepository.class)).thenReturn(this.apiKeyRepository);
+        when(this.executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(ApiKeyPolicyTest.API_NAME_HEADER_VALUE);
+        when(this.apiKeyRepository.findById(ApiKeyPolicyTest.API_KEY_HEADER_VALUE)).thenReturn(Optional.of(invalidApiKey));
+
+        when(this.apiKeyPolicyConfiguration.isPropagateApiKey()).thenReturn(true);
+        final io.gravitee.policy.apikey.configuration.Response responseConfig = new io.gravitee.policy.apikey.configuration.Response();
+        responseConfig.setContentType(MediaType.APPLICATION_JSON);
+        responseConfig.setType(ErrorType.WRONG_EXPIRED_REVOKED);
+        responseConfig.setStatusCode(499);
+        responseConfig.setContent("{\"error\":\"not allowed\"}");
+        when(this.apiKeyPolicyConfiguration.getResponses()).thenReturn(Collections.singletonList(responseConfig));
+        this.apiKeyPolicy.onRequest(this.request, this.response, this.executionContext, this.policyChain);
+
+        verify(this.apiKeyRepository).findById(ApiKeyPolicyTest.API_KEY_HEADER_VALUE);
+        verify(this.policyChain, times(0)).doNext(this.request, this.response);
+        verify(this.policyChain).failWith(any(PolicyResult.class));
+        // TODO check the content of the PolicyResult Assert.assertEquals(499, any.httpStatusCode());
+    }
+
+    /**
+     * test case for a configured response where the request do not match a configured response.
+     *
+     * @throws TechnicalException
+     * @since 1.6.3
+     */
+    @Test
+    public void testResponseConfigurationNoMatch() throws TechnicalException {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setAll(new HashMap<String, String>() {
+
+            {
+                this.put(X_GRAVITEE_API_KEY, ApiKeyPolicyTest.API_KEY_HEADER_VALUE);
+                this.put("Accept", MediaType.APPLICATION_JSON);
+            }
+        });
+
+        final ApiKey invalidApiKey = new ApiKey();
+        invalidApiKey.setRevoked(true);
+        invalidApiKey.setPlan(ApiKeyPolicyTest.PLAN_NAME_HEADER_VALUE);
+
+        when(this.request.headers()).thenReturn(headers);
+        when(this.executionContext.getComponent(ApiKeyRepository.class)).thenReturn(this.apiKeyRepository);
+        when(this.executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(ApiKeyPolicyTest.API_NAME_HEADER_VALUE);
+        when(this.apiKeyRepository.findById(ApiKeyPolicyTest.API_KEY_HEADER_VALUE)).thenReturn(Optional.of(invalidApiKey));
+
+        when(this.apiKeyPolicyConfiguration.isPropagateApiKey()).thenReturn(true);
+        final io.gravitee.policy.apikey.configuration.Response responseConfig = new io.gravitee.policy.apikey.configuration.Response();
+        responseConfig.setContentType(MediaType.APPLICATION_JSON);
+        responseConfig.setType(ErrorType.MISSING);
+        responseConfig.setStatusCode(499);
+        responseConfig.setContent("{\"error\":\"not allowed\"}");
+        when(this.apiKeyPolicyConfiguration.getResponses()).thenReturn(Collections.singletonList(responseConfig));
+        this.apiKeyPolicy.onRequest(this.request, this.response, this.executionContext, this.policyChain);
+
+        verify(this.apiKeyRepository).findById(ApiKeyPolicyTest.API_KEY_HEADER_VALUE);
+        verify(this.policyChain, times(0)).doNext(this.request, this.response);
+        verify(this.policyChain).failWith(any(PolicyResult.class));
+        // TODO check the content of the PolicyResult Assert.assertEquals(401, any.httpStatusCode());
     }
 }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -118,6 +118,33 @@ public class ApiKeyPolicyTest {
     }
 
     @Test
+    public void test_withNullConfiguration() throws TechnicalException {
+
+        apiKeyPolicy = new ApiKeyPolicy(null);
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setAll(new HashMap<String, String>() {
+            {
+                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
+            }
+        });
+
+        final ApiKey validApiKey = new ApiKey();
+        validApiKey.setRevoked(false);
+        validApiKey.setPlan(PLAN_NAME_HEADER_VALUE);
+
+        when(request.headers()).thenReturn(headers);
+        when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
+        when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
+        when(apiKeyRepository.findById(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+
+        apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
+
+        verify(apiKeyRepository).findById(API_KEY_HEADER_VALUE);
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
     public void testOnRequest_withUnexpiredKey() throws TechnicalException {
         final HttpHeaders headers = new HttpHeaders();
         headers.setAll(new HashMap<String, String>() {

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -368,7 +368,6 @@ public class ApiKeyPolicyTest {
     }
 
     @Test
-    @Ignore
     public void testApiKey_propagated() throws TechnicalException{
         final HttpHeaders headers = new HttpHeaders();
         headers.setAll(new HashMap<String, String>() {


### PR DESCRIPTION
This PR adds a dynamic configuration for error responses to the API key policy. A configuration example can be seen below.
The configuration contains an error type, content type and a response content with a response status code. The content type is matched against the ``Accept`` header send to the gateway. So you can configure different payloads for different requests (by Accept header). The error type can be one of MISSING (no API key send) or WRONG_EXPIRED_REVOKED. Different payloads for the error cases are possible.
In the ApiKeyPolicy class the configuration is used to find the matching response. If none is matching the default is used for backward compatibility.

2: https://github.com/gravitee-io/gravitee-gateway/pull/388
Is needed to enable payloads different than JSON and to answer with the configured response even if no API key is send.

3: https://github.com/gravitee-io/gravitee-policy-api/pull/12
Is needed to enable payloads different than JSON.

configuration example:
![image](https://user-images.githubusercontent.com/2338960/49934644-383ce380-fecf-11e8-8d13-28784ce098fb.png)
![image](https://user-images.githubusercontent.com/2338960/49934676-51de2b00-fecf-11e8-85cb-fdf977aa4283.png)
![image](https://user-images.githubusercontent.com/2338960/49934699-5e628380-fecf-11e8-96ad-893c1d57cdb5.png)
