### PR TITLE
feat(policy): invalid api-keys return 401 instead of 403

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Description of the ApiKey Gravitee Policy</description>

--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -98,7 +98,7 @@ public class ApiKeyPolicy {
                         policyChain.failWith(
                                 PolicyResult.failure(
                                         API_KEY_INVALID_KEY,
-                                        HttpStatusCode.FORBIDDEN_403,
+                                        HttpStatusCode.UNAUTHORIZED_401,
                                         "API Key is not valid or is expired / revoked."));
                     }
                 } else {
@@ -106,7 +106,7 @@ public class ApiKeyPolicy {
                     policyChain.failWith(
                             PolicyResult.failure(
                                     API_KEY_INVALID_KEY,
-                                    HttpStatusCode.FORBIDDEN_403,
+                                    HttpStatusCode.UNAUTHORIZED_401,
                                     "API Key is not valid or is expired / revoked."));
                 }
             } catch (TechnicalException te) {


### PR DESCRIPTION
This is a breaking change for API customers
Closes gravitee-io/issues#2842