### PR TITLE
Feat/6006 handle duplicate api keys

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -77,7 +77,9 @@ public class ApiKeyPolicy {
                                     + ") or query parameters (" + API_KEY_QUERY_PARAMETER + ")."));
         } else {
             try {
-                Optional<ApiKey> apiKeyOpt = executionContext.getComponent(ApiKeyRepository.class).findByKey(requestApiKey);
+                final String apiId = (String) executionContext.getAttribute(ExecutionContext.ATTR_API);
+
+                Optional<ApiKey> apiKeyOpt = executionContext.getComponent(ApiKeyRepository.class).findByKeyAndApi(requestApiKey, apiId);
                 if (apiKeyOpt.isPresent()) {
                     ApiKey apiKey = apiKeyOpt.get();
 
@@ -87,8 +89,6 @@ public class ApiKeyPolicy {
                     // Be sure to force the plan to the one linked to the apikey
                     executionContext.setAttribute(ExecutionContext.ATTR_PLAN, apiKey.getPlan());
                     executionContext.setAttribute(ATTR_API_KEY, apiKey.getKey());
-
-                    final String apiId = (String) executionContext.getAttribute(ExecutionContext.ATTR_API);
 
                     if (!apiKey.isRevoked()
                             && (apiKey.getExpireAt() == null || apiKey.getExpireAt().after(new Date(request.timestamp())))) {

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -107,11 +107,11 @@ public class ApiKeyPolicyTest {
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -134,11 +134,11 @@ public class ApiKeyPolicyTest {
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -161,11 +161,11 @@ public class ApiKeyPolicyTest {
         when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -191,11 +191,11 @@ public class ApiKeyPolicyTest {
         when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -218,11 +218,11 @@ public class ApiKeyPolicyTest {
 
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -246,11 +246,11 @@ public class ApiKeyPolicyTest {
         when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain, times(0)).doNext(request, response);
     }
 
@@ -273,11 +273,11 @@ public class ApiKeyPolicyTest {
         when(request.timestamp()).thenReturn(requestDate.toEpochMilli());
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain, times(0)).doNext(request, response);
         verify(policyChain).failWith(any(PolicyResult.class));
     }
@@ -311,11 +311,11 @@ public class ApiKeyPolicyTest {
 
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -334,7 +334,8 @@ public class ApiKeyPolicyTest {
 
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
-        when(apiKeyRepository.findByKey(notExistingApiKey)).thenReturn(Optional.empty());
+        when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
+        when(apiKeyRepository.findByKeyAndApi(notExistingApiKey, API_NAME_HEADER_VALUE)).thenReturn(Optional.empty());
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
@@ -357,7 +358,7 @@ public class ApiKeyPolicyTest {
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(invalidApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(invalidApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
@@ -381,17 +382,17 @@ public class ApiKeyPolicyTest {
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         (new ApiKeyPolicy(null)).onRequest(request, response, executionContext, policyChain);
 
         Assert.assertFalse(request.headers().containsKey(X_GRAVITEE_API_KEY));
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
     @Test
-    public void testApiKey_notPropagatedBeacauseItsAsked() throws TechnicalException{
+    public void testApiKey_notPropagatedBecauseItsAsked() throws TechnicalException{
         final HttpHeaders headers = new HttpHeaders();
         headers.setAll(new HashMap<String, String>() {
             {
@@ -406,12 +407,12 @@ public class ApiKeyPolicyTest {
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
         Assert.assertFalse(request.headers().containsKey(X_GRAVITEE_API_KEY));
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 
@@ -431,13 +432,13 @@ public class ApiKeyPolicyTest {
         when(request.headers()).thenReturn(headers);
         when(executionContext.getComponent(ApiKeyRepository.class)).thenReturn(apiKeyRepository);
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_NAME_HEADER_VALUE);
-        when(apiKeyRepository.findByKey(API_KEY_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
+        when(apiKeyRepository.findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE)).thenReturn(Optional.of(validApiKey));
 
         when(apiKeyPolicyConfiguration.isPropagateApiKey()).thenReturn(true);
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
         Assert.assertTrue(request.headers().containsKey(X_GRAVITEE_API_KEY));
-        verify(apiKeyRepository).findByKey(API_KEY_HEADER_VALUE);
+        verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
 }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -93,12 +93,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testOnRequest() throws TechnicalException {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
 
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
@@ -120,12 +115,7 @@ public class ApiKeyPolicyTest {
 
         apiKeyPolicy = new ApiKeyPolicy(null);
 
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
 
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
@@ -144,12 +134,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testOnRequest_withUnexpiredKey() throws TechnicalException {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
         validApiKey.setExpireAt(new Date());
@@ -174,12 +159,7 @@ public class ApiKeyPolicyTest {
         final String customHeader = "My-Custom-Api-Key";
         when(environment.getProperty(eq(ApiKeyPolicy.API_KEY_HEADER_PROPERTY), anyString())).thenReturn(customHeader);
 
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(customHeader, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(customHeader, API_KEY_HEADER_VALUE);
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
         validApiKey.setExpireAt(new Date());
@@ -229,12 +209,7 @@ public class ApiKeyPolicyTest {
     @Test
     @Ignore
     public void testOnRequest_withUnexpiredKeyAndBadApi() throws TechnicalException {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
         validApiKey.setExpireAt(new Date());
@@ -256,12 +231,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testOnRequest_withExpiredKey() throws TechnicalException {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
         validApiKey.setExpireAt(new Date());
@@ -322,12 +292,7 @@ public class ApiKeyPolicyTest {
     @Test
     public void testOnRequestFailBecauseApiKeyNotFoundOnRepository() throws TechnicalException {
         final String notExistingApiKey = "not_existing_api_key";
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, notExistingApiKey);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, notExistingApiKey);
 
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
@@ -345,12 +310,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testOnRequestFailBecauseApiKeyFoundButNotActive() throws TechnicalException{
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
         final ApiKey invalidApiKey = new ApiKey();
         invalidApiKey.setRevoked(true);
 
@@ -368,12 +328,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testApiKey_notPropagatedBecauseNoConfig() throws TechnicalException{
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
 
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
@@ -393,12 +348,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testApiKey_notPropagatedBecauseItsAsked() throws TechnicalException{
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
 
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
@@ -418,12 +368,7 @@ public class ApiKeyPolicyTest {
 
     @Test
     public void testApiKey_propagated() throws TechnicalException{
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setAll(new HashMap<String, String>() {
-            {
-                put(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
-            }
-        });
+        final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY, API_KEY_HEADER_VALUE);
 
         final ApiKey validApiKey = new ApiKey();
         validApiKey.setRevoked(false);
@@ -440,5 +385,15 @@ public class ApiKeyPolicyTest {
         Assert.assertTrue(request.headers().containsKey(X_GRAVITEE_API_KEY));
         verify(apiKeyRepository).findByKeyAndApi(API_KEY_HEADER_VALUE, API_NAME_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
+    }
+
+    private HttpHeaders buildHttpHeaders(String headerKey, String headerValue) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAll(new HashMap<String, String>() {
+            {
+                put(headerKey, headerValue);
+            }
+        });
+        return headers;
     }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6006

Now we permit multiple API Keys with same key.
To find the unique one, we have to search with two criterias : key and api.