### PR TITLE
Update CI to check if SNAPSHOT qualifier is ok now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@dev:2.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)


### PR DESCRIPTION
**Issue**

NA

**Description**

WIP
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.0-update-ci-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/2.5.0-update-ci-SNAPSHOT/gravitee-policy-apikey-2.5.0-update-ci-SNAPSHOT.zip)
  <!-- Version placeholder end -->
