### PR TITLE
test: test policy with APIM Gateway SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,20 +30,36 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>15.1</version>
+        <version>20.1</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-repository-api.version>3.12.0</gravitee-repository-api.version>
+        <gravitee-repository-api.version>3.17.0</gravitee-repository-api.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee.io dependencies -->
@@ -72,7 +88,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -80,20 +95,26 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -164,5 +185,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyIntegrationTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.apikey;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.handlers.api.definition.ApiKey;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.model.Subscription;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/api-key.json")
+class ApiKeyPolicyIntegrationTest extends AbstractPolicyTest<ApiKeyPolicy, ApiKeyPolicyConfiguration> {
+
+    /**
+     * Override api plans to have a published API_KEY one.
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+        Plan apiKeyPlan = new Plan();
+        apiKeyPlan.setId("plan-id");
+        apiKeyPlan.setApi(api.getId());
+        apiKeyPlan.setSecurity("API_KEY");
+        apiKeyPlan.setStatus("PUBLISHED");
+        apiKeyPlan.setSecurityDefinition("{\"propagateApiKey\":true}");
+        api.setPlans(Collections.singletonList(apiKeyPlan));
+    }
+
+    @Test
+    @DisplayName("Should receive 401 - Unauthorized we calling without an API-Key")
+    void shouldGet401IfNoApiKey(WebClient client) {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.bodyAsString()).isEqualTo("Unauthorized");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DisplayName("Should access API with API-Key header")
+    void shouldAccessApiWithApiKeyHeader(WebClient client) throws TechnicalException {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        final ApiKey apiKey = fakeApiKeyFromDb();
+
+        when(getBean(ApiKeyRepository.class).findByKeyAndApi(any(), any())).thenReturn(Optional.of(apiKey));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").putHeader("X-Gravitee-Api-Key", "apiKeyValue").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.bodyAsString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DisplayName("Should access API with API-Key query param")
+    void shouldAccessApiWithApiKeyQueryParam(WebClient client) throws TechnicalException {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        final ApiKey apiKey = fakeApiKeyFromDb();
+
+        when(getBean(ApiKeyRepository.class).findByKeyAndApi(any(), any())).thenReturn(Optional.of(apiKey));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").addQueryParam("api-key", "apiKeyValue").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.bodyAsString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    /**
+     * Generate the ApiKey object that would be returned by the ApiKeyRepository
+     * @return the ApiKey object
+     */
+    private ApiKey fakeApiKeyFromDb() {
+        final io.gravitee.repository.management.model.ApiKey repoApiKey = new io.gravitee.repository.management.model.ApiKey();
+        repoApiKey.setApplication("application-id");
+        repoApiKey.setSubscription("subscription-id");
+        repoApiKey.setPlan("plan-id");
+        repoApiKey.setKey("key-id");
+
+        Subscription subscription = new Subscription();
+        subscription.setPlan("plan-id");
+        subscription.setId("subscription-id");
+        subscription.setStatus(Subscription.Status.ACCEPTED);
+
+        final ApiKey apiKey = new ApiKey(repoApiKey, subscription);
+        return apiKey;
+    }
+}

--- a/src/test/resources/apis/api-key.json
+++ b/src/test/resources/apis/api-key.json
@@ -1,0 +1,42 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Api Key",
+          "description": "",
+          "enabled": true,
+          "policy": "api-key",
+          "configuration": {}
+        }
+      ],
+      "post": []
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7720

**Description**

Test policy with Gateway Testing SDK
Tests are done using a real API

- [x]  Should be unauthorized if not using an api key
- [x]  Should access api with api-key header
- [x]  Should access api with api-key param
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.4.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/2.4.0/gravitee-policy-apikey-2.4.0.zip)
  <!-- Version placeholder end -->
