### PR TITLE
feat: use services instead of repositoryWrappers and validate subscription

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>2.5.0</version>
+    <version>2.6.0-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Description of the ApiKey Gravitee Policy</description>
@@ -35,9 +35,8 @@
 
     <properties>
         <gravitee-bom.version>2.5</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.33.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.36.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-repository-api.version>3.18.0-SNAPSHOT</gravitee-repository-api.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas
         </json-schema-generator-maven-plugin.outputDirectory>
@@ -47,7 +46,7 @@
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.19.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-node-api.version>1.21.0</gravitee-node-api.version>
         <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
@@ -110,13 +109,6 @@
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
             <version>${gravitee-policy-api.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.apim.repository</groupId>
-            <artifactId>gravitee-apim-repository-api</artifactId>
-            <version>${gravitee-repository-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyIntegrationTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.apikey;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static java.time.temporal.ChronoUnit.HOURS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -27,16 +28,18 @@ import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuil
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.Plan;
-import io.gravitee.gateway.handlers.api.definition.ApiKey;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.ApiKeyRepository;
-import io.gravitee.repository.management.model.Subscription;
 import io.reactivex.observers.TestObserver;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
 import io.vertx.reactivex.ext.web.client.WebClient;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,14 +76,13 @@ public class ApiKeyPolicyIntegrationTest extends AbstractPolicyTest<ApiKeyPolicy
     }
 
     @Test
-    @DisplayName("Should receive 401 - Unauthorized we calling without an API-Key")
+    @DisplayName("Should receive 401 - Unauthorized when calling without an API-Key")
     void shouldGet401IfNoApiKey(WebClient client) {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
 
         final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(response -> {
                 assertThat(response.statusCode()).isEqualTo(401);
@@ -93,18 +95,67 @@ public class ApiKeyPolicyIntegrationTest extends AbstractPolicyTest<ApiKeyPolicy
     }
 
     @Test
-    @DisplayName("Should access API with API-Key header")
-    void shouldAccessApiWithApiKeyHeader(WebClient client) throws TechnicalException {
+    @DisplayName("Should receive 401 - Unauthorized when calling with an API key, without subscription")
+    void shouldGet401IfNoSubscription(WebClient client) {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
 
-        final ApiKey apiKey = fakeApiKeyFromDb();
+        final ApiKey apiKey = fakeApiKeyFromCache();
 
-        when(getBean(ApiKeyRepository.class).findByKeyAndApi(any(), any())).thenReturn(Optional.of(apiKey));
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        when(getBean(SubscriptionService.class).getById(any())).thenReturn(Optional.empty());
 
         final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").putHeader("X-Gravitee-Api-Key", "apiKeyValue").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.bodyAsString()).isEqualTo("API Key is not valid or is expired / revoked.");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DisplayName("Should receive 401 - Unauthorized when calling with an API key, with expired subscription")
+    void shouldGet401IfExpiredSubscription(WebClient client) {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        final ApiKey apiKey = fakeApiKeyFromCache();
+
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        when(getBean(SubscriptionService.class).getById(any())).thenReturn(Optional.of(fakeSubscriptionFromCache(true)));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").putHeader("X-Gravitee-Api-Key", "apiKeyValue").rxSend().test();
+
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.bodyAsString()).isEqualTo("API Key is not valid or is expired / revoked.");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DisplayName("Should access API with API-Key header")
+    void shouldAccessApiWithApiKeyHeader(WebClient client) {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        final ApiKey apiKey = fakeApiKeyFromCache();
+
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        when(getBean(SubscriptionService.class).getById(apiKey.getSubscription()))
+            .thenReturn(Optional.of(fakeSubscriptionFromCache(false)));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").putHeader("X-Gravitee-Api-Key", "apiKeyValue").rxSend().test();
+
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
@@ -118,17 +169,17 @@ public class ApiKeyPolicyIntegrationTest extends AbstractPolicyTest<ApiKeyPolicy
 
     @Test
     @DisplayName("Should access API with API-Key query param")
-    void shouldAccessApiWithApiKeyQueryParam(WebClient client) throws TechnicalException {
+    void shouldAccessApiWithApiKeyQueryParam(WebClient client) {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
 
-        final ApiKey apiKey = fakeApiKeyFromDb();
+        final ApiKey apiKey = fakeApiKeyFromCache();
 
-        when(getBean(ApiKeyRepository.class).findByKeyAndApi(any(), any())).thenReturn(Optional.of(apiKey));
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        when(getBean(SubscriptionService.class).getById("subscription-id")).thenReturn(Optional.of(fakeSubscriptionFromCache(false)));
 
         final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").addQueryParam("api-key", "apiKeyValue").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
@@ -141,21 +192,30 @@ public class ApiKeyPolicyIntegrationTest extends AbstractPolicyTest<ApiKeyPolicy
     }
 
     /**
-     * Generate the ApiKey object that would be returned by the ApiKeyRepository
+     * Generate the ApiKey object that would be returned by the ApiKeyService
      * @return the ApiKey object
      */
-    private ApiKey fakeApiKeyFromDb() {
-        final io.gravitee.repository.management.model.ApiKey repoApiKey = new io.gravitee.repository.management.model.ApiKey();
-        repoApiKey.setApplication("application-id");
-        repoApiKey.setSubscription("subscription-id");
-        repoApiKey.setPlan("plan-id");
-        repoApiKey.setKey("key-id");
+    private ApiKey fakeApiKeyFromCache() {
+        final ApiKey apiKey = new ApiKey();
+        apiKey.setApplication("application-id");
+        apiKey.setSubscription("subscription-id");
+        apiKey.setPlan("plan-id");
+        apiKey.setKey("key-id");
+        return apiKey;
+    }
 
-        Subscription subscription = new Subscription();
-        subscription.setPlan("plan-id");
+    /**
+     * Generate the Subscription object that would be returned by the SubscriptionService
+     * @return the Subscription object
+     */
+    private Subscription fakeSubscriptionFromCache(boolean isExpired) {
+        final Subscription subscription = new Subscription();
+        subscription.setApplication("application-id");
         subscription.setId("subscription-id");
-        subscription.setStatus(Subscription.Status.ACCEPTED);
-
-        return new ApiKey(repoApiKey, subscription);
+        subscription.setPlan("plan-id");
+        if (isExpired) {
+            subscription.setEndingAt(new Date(Instant.now().minus(1, HOURS).toEpochMilli()));
+        }
+        return subscription;
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7360

**Description**

feat: use services instead of repositoryWrappers and validate subscription

Policies should never access to underlying repository directly,
So they use new services to manage api keys and subscriptions, instead of repositoryWrappers.

Subscription validity check is enabled, as a shared API key can be linked to an expired subscription.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.0-refactor-apiKeysAndSubsManagers-jupiter-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/2.6.0-refactor-apiKeysAndSubsManagers-jupiter-SNAPSHOT/gravitee-policy-apikey-2.6.0-refactor-apiKeysAndSubsManagers-jupiter-SNAPSHOT.zip)
  <!-- Version placeholder end -->
