### PR TITLE
chore: move version to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.0</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Description of the ApiKey Gravitee Policy</description>


### PR DESCRIPTION
**Description**
Remove snapshot version from pom, which makes semantic release fail

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
