### PR TITLE
feat: migrate to the new version of Jupiter's SecurityPolicy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.38.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.39.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas

--- a/src/test/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3IntegrationTest.java
@@ -15,10 +15,18 @@
  */
 package io.gravitee.policy.v3.apikey;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.policy.apikey.ApiKeyPolicyIntegrationTest;
+import java.util.Optional;
+import org.mockito.stubbing.OngoingStubbing;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -36,5 +44,25 @@ public class ApiKeyPolicyV3IntegrationTest extends ApiKeyPolicyIntegrationTest {
     public void configureApi(Api api) {
         super.configureApi(api);
         api.setExecutionMode(ExecutionMode.V3);
+    }
+
+    /**
+     * This overrides subscription search :
+     * - in jupiter its searched with getByApiAndSecurityToken
+     * - in V3 its searches with getById
+     */
+    @Override
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(ApiKey apiKey) {
+        return when(getBean(SubscriptionService.class).getById(apiKey.getSubscription()));
+    }
+
+    /**
+     * This overrides 401 response HTTP body content assertion :
+     * - in jupiter, it's "unauthorized"
+     * - in V3, it contains more information
+     */
+    @Override
+    protected void assertUnauthorizedResponseBody(String responseBody) {
+        assertThat(responseBody).isEqualTo("API Key is not valid or is expired / revoked.");
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7991
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.8.0-feat-jupiterPlans-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/2.8.0-feat-jupiterPlans-SNAPSHOT/gravitee-policy-apikey-2.8.0-feat-jupiterPlans-SNAPSHOT.zip)
  <!-- Version placeholder end -->
