### PR TITLE
fix(deps): upgrade gravitee-bom & alpha version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,16 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
         <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>2.7</gravitee-bom.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
-        <gravitee-expression-language.version>2.1.0-alpha.1</gravitee-expression-language.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.18</gravitee-gateway-api.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
+        <gravitee-expression-language.version>2.1.0</gravitee-expression-language.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-node.version>2.0.1</gravitee-node.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-upgrade-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/3.1.0-upgrade-deps-SNAPSHOT/gravitee-policy-apikey-3.1.0-upgrade-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
