### PR TITLE
fix: clean schema-form to make it compatible with gio-form-json-schem…

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,10 +1,11 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:apikey:configuration:ApiKeyPolicyConfiguration",
-  "properties" : {
-    "propagateApiKey" : {
-      "title": "Propagate API Key to upstream API",
-      "type" : "boolean"
-    }
-  }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "propagateApiKey": {
+            "title": "Propagate API Key to upstream API",
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": false
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1450

**Description**

Update schema-form to make them compatible with the new gio-form-json-schema component.

to validate these changes it is necessary that it works with the old and the new  UI component 
and also with backend rest-api check

 Old :
 Online checker : https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
 
 New :
 Online checker : https://particles.gravitee.io/?path=/story/components-form-json-schema--string

**Additional context**

PR linked which will be tested with the temporary version in apim

- https://github.com/gravitee-io/gravitee-ui-particles/pull/223
- https://github.com/gravitee-io/gravitee-policy-jwt/pull/92
- https://github.com/gravitee-io/gravitee-policy-apikey/pull/63
- https://github.com/gravitee-io/gravitee-policy-oauth2/pull/68
- https://github.com/gravitee-io/gravitee-api-management/pull/3686

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.1-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/3.1.1-json-schema-SNAPSHOT/gravitee-policy-apikey-3.1.1-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
