### PR TITLE
feat(apikey): Set the apikey value into the context to retrieve it la…

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -120,6 +120,9 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements SecurityPolicy {
                         .getComponent(ApiKeyService.class)
                         .getByApiAndKey(ctx.getAttribute(ContextAttributes.ATTR_API), requestApiKey.get());
 
+                    // Always set the apikey into the context
+                    ctx.setAttribute(ATTR_API_KEY, requestApiKey.get());
+
                     if (apiKeyOpt.isPresent()) {
                         ApiKey apiKey = apiKeyOpt.get();
 

--- a/src/test/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3Test.java
@@ -83,8 +83,6 @@ public class ApiKeyPolicyV3Test {
     @BeforeEach
     void init() {
         apiKeyPolicy = new ApiKeyPolicy(apiKeyPolicyConfiguration);
-        ApiKeyPolicyV3.API_KEY_QUERY_PARAMETER = null;
-        ApiKeyPolicyV3.API_KEY_HEADER = null;
         lenient().when(executionContext.getComponent(Environment.class)).thenReturn(environment);
         lenient()
             .when(environment.getProperty(eq(ApiKeyPolicyV3.API_KEY_HEADER_PROPERTY), anyString()))
@@ -109,6 +107,7 @@ public class ApiKeyPolicyV3Test {
 
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
+        verify(executionContext).setAttribute(ApiKeyPolicyV3.ATTR_API_KEY, API_KEY_HEADER_VALUE);
         verify(apiKeyService).getByApiAndKey(API_NAME_HEADER_VALUE, API_KEY_HEADER_VALUE);
         verify(policyChain).doNext(request, response);
     }
@@ -227,6 +226,7 @@ public class ApiKeyPolicyV3Test {
         apiKeyPolicy.onRequest(request, response, executionContext, policyChain);
 
         verify(apiKeyService).getByApiAndKey(API_NAME_HEADER_VALUE, API_KEY_HEADER_VALUE);
+        verify(executionContext).setAttribute(ApiKeyPolicyV3.ATTR_API_KEY, API_KEY_HEADER_VALUE);
         verify(policyChain, times(0)).doNext(request, response);
         verify(policyChain).failWith(any(PolicyResult.class));
     }


### PR DESCRIPTION
…ter, even it the apikey is not valid

**Issue**

https://gravitee.atlassian.net/browse/APIM-1499

**Description**

Propagate the apikey value into the context of the request for further retrieval.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.0-apim-1498-set-apikey-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/3.2.0-apim-1498-set-apikey-context-SNAPSHOT/gravitee-policy-apikey-3.2.0-apim-1498-set-apikey-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
