### PR TITLE
fix: provide execution phase for message apis in manifest

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -7,3 +7,4 @@ type=policy
 category=security
 icon=api-key.svg
 proxy=REQUEST
+message=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1702

**Description**

In the previous change, I forgot to define the phase for `message` APIs 🙈 
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.1-apim1705-bis-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/3.2.1-apim1705-bis-SNAPSHOT/gravitee-policy-apikey-3.2.1-apim1705-bis-SNAPSHOT.zip)
  <!-- Version placeholder end -->
