### PR TITLE
fix: simplify unauthorized message

### DIFF
--- a/src/main/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3.java
@@ -40,7 +40,7 @@ public class ApiKeyPolicyV3 {
 
     protected static final String API_KEY_MISSING_KEY = "API_KEY_MISSING";
     protected static final String API_KEY_INVALID_KEY = "API_KEY_INVALID";
-    protected static final String API_KEY_INVALID_MESSAGE = "API Key is not valid or is expired / revoked.";
+    protected static final String API_KEY_UNAUTHORIZED_MESSAGE = "Unauthorized";
 
     /**
      * Policy configuration
@@ -63,17 +63,7 @@ public class ApiKeyPolicyV3 {
 
         if (requestApiKey == null || requestApiKey.isEmpty()) {
             // The api key is required
-            policyChain.failWith(
-                PolicyResult.failure(
-                    API_KEY_MISSING_KEY,
-                    HttpStatusCode.UNAUTHORIZED_401,
-                    "No API Key has been specified in headers (" +
-                    API_KEY_HEADER +
-                    ") or query parameters (" +
-                    API_KEY_QUERY_PARAMETER +
-                    ")."
-                )
-            );
+            policyChain.failWith(PolicyResult.failure(API_KEY_MISSING_KEY, HttpStatusCode.UNAUTHORIZED_401, API_KEY_UNAUTHORIZED_MESSAGE));
         } else {
             final String apiId = (String) executionContext.getAttribute(ExecutionContext.ATTR_API);
 
@@ -93,12 +83,14 @@ public class ApiKeyPolicyV3 {
                 } else {
                     // The api key is not valid
                     policyChain.failWith(
-                        PolicyResult.failure(API_KEY_INVALID_KEY, HttpStatusCode.UNAUTHORIZED_401, API_KEY_INVALID_MESSAGE)
+                        PolicyResult.failure(API_KEY_INVALID_KEY, HttpStatusCode.UNAUTHORIZED_401, API_KEY_UNAUTHORIZED_MESSAGE)
                     );
                 }
             } else {
                 // The api key does not exist
-                policyChain.failWith(PolicyResult.failure(API_KEY_INVALID_KEY, HttpStatusCode.UNAUTHORIZED_401, API_KEY_INVALID_MESSAGE));
+                policyChain.failWith(
+                    PolicyResult.failure(API_KEY_INVALID_KEY, HttpStatusCode.UNAUTHORIZED_401, API_KEY_UNAUTHORIZED_MESSAGE)
+                );
             }
         }
     }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -295,10 +295,7 @@ public class ApiKeyPolicyTest {
             .interruptWith(
                 argThat(failure -> {
                     assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
-                    assertEquals(
-                        "No API Key has been specified in headers (X-Gravitee-Api-Key) or query parameters (api-key).",
-                        failure.message()
-                    );
+                    assertEquals("Unauthorized", failure.message());
                     assertEquals("API_KEY_MISSING", failure.key());
                     assertNull(failure.parameters());
                     assertNull(failure.contentType());
@@ -327,7 +324,7 @@ public class ApiKeyPolicyTest {
             .interruptWith(
                 argThat(failure -> {
                     assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
-                    assertEquals("API Key is not valid or is expired / revoked.", failure.message());
+                    assertEquals("Unauthorized", failure.message());
                     assertEquals("API_KEY_INVALID", failure.key());
                     assertNull(failure.parameters());
                     assertNull(failure.contentType());
@@ -356,7 +353,7 @@ public class ApiKeyPolicyTest {
             .interruptWith(
                 argThat(failure -> {
                     assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
-                    assertEquals("API Key is not valid or is expired / revoked.", failure.message());
+                    assertEquals("Unauthorized", failure.message());
                     assertEquals("API_KEY_INVALID", failure.key());
                     assertNull(failure.parameters());
                     assertNull(failure.contentType());
@@ -384,7 +381,7 @@ public class ApiKeyPolicyTest {
             .interruptWith(
                 argThat(failure -> {
                     assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
-                    assertEquals("API Key is not valid or is expired / revoked.", failure.message());
+                    assertEquals("Unauthorized", failure.message());
                     assertEquals("API_KEY_INVALID", failure.key());
                     assertNull(failure.parameters());
                     assertNull(failure.contentType());
@@ -409,7 +406,7 @@ public class ApiKeyPolicyTest {
             .interruptWith(
                 argThat(failure -> {
                     assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
-                    assertEquals("API Key is not valid or is expired / revoked.", failure.message());
+                    assertEquals("Unauthorized", failure.message());
                     assertEquals("API_KEY_INVALID", failure.key());
                     assertNull(failure.parameters());
                     assertNull(failure.contentType());


### PR DESCRIPTION
**Description**

  - to avoid giving too much information, all error will only return Unauthorized as message.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-simplify-error-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/4.0.0-simplify-error-message-SNAPSHOT/gravitee-policy-apikey-4.0.0-simplify-error-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
