### PR TITLE
fix: properly handle api key extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.7</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.9</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-node.version>3.1.0-alpha.10</gravitee-node.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>


### PR DESCRIPTION

**Description**

  - no header or query param will not return any token
  - if header or query param are present :
     - if not empty  an invalid token is returned
     - if empty an invalid token is returned
     - 
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-properly-handle-empty-apikey-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/4.0.0-properly-handle-empty-apikey-SNAPSHOT/gravitee-policy-apikey-4.0.0-properly-handle-empty-apikey-SNAPSHOT.zip)
  <!-- Version placeholder end -->
