### PR TITLE
Implement methods for native security chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Logging dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-apikey</artifactId>
-    <version>4.0.1</version>
+    <version>5.0.0-apim-7143-impl-security-chain-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - ApiKey</name>
     <description>Enforce API Key checks during request processing, allowing only apps with approved API keys to access your APIs</description>
@@ -30,18 +30,12 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.2.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
 
-        <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
 
         <!-- Property used by the publication job in CI-->
@@ -52,26 +46,11 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.common</groupId>
-                <artifactId>gravitee-common</artifactId>
-                <version>${gravitee-common.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -168,7 +147,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -15,17 +15,19 @@
  */
 package io.gravitee.policy.apikey;
 
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.MD5_API_KEY;
+
 import io.gravitee.common.http.GraviteeHttpHeader;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
-import io.gravitee.gateway.reactive.api.context.HttpPlainExecutionContext;
-import io.gravitee.gateway.reactive.api.context.HttpRequest;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
-import io.gravitee.gateway.reactive.api.policy.SecurityPolicy;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.api.policy.http.HttpSecurityPolicy;
 import io.gravitee.gateway.reactive.api.policy.kafka.KafkaSecurityPolicy;
@@ -33,25 +35,35 @@ import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
 import io.gravitee.policy.v3.apikey.ApiKeyPolicyV3;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import java.security.SecureRandom;
 import java.util.Date;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.function.Function;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.security.plain.PlainAuthenticateCallback;
+import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.ScramCredentialCallback;
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy {
+@Slf4j
+public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy, KafkaSecurityPolicy {
 
     static final String ATTR_API_KEY = ContextAttributes.ATTR_PREFIX + "api-key";
     static final String ATTR_INTERNAL_API_KEY = "api-key";
+    static final String ATTR_INTERNAL_MD5_API_KEY = "md5-api-key";
     static final String API_KEY_HEADER_PROPERTY = "policy.api-key.header";
     static final String API_KEY_QUERY_PARAMETER_PROPERTY = "policy.api-key.param";
     static final String DEFAULT_API_KEY_QUERY_PARAMETER = "api-key";
     static final String DEFAULT_API_KEY_HEADER_PARAMETER = GraviteeHttpHeader.X_GRAVITEE_API_KEY;
-    private static final Logger log = LoggerFactory.getLogger(ApiKeyPolicy.class);
     static String API_KEY_HEADER, API_KEY_QUERY_PARAMETER;
     private final boolean propagateApiKey;
 
@@ -71,7 +83,7 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy {
         if (apiKeyOpt.isPresent()) {
             String apiKey = apiKeyOpt.get();
             if (apiKey.isBlank()) {
-                return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.API_KEY));
+                return Maybe.just(SecurityToken.invalid(API_KEY));
             }
             ctx.setInternalAttribute(ATTR_INTERNAL_API_KEY, apiKey);
             return Maybe.just(SecurityToken.forApiKey(apiKey));
@@ -120,18 +132,8 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy {
                         .getComponent(ApiKeyService.class)
                         .getByApiAndKey(ctx.getAttribute(ContextAttributes.ATTR_API), requestApiKey.get());
 
-                    if (apiKeyOpt.isPresent()) {
-                        ApiKey apiKey = apiKeyOpt.get();
-
-                        // Add data about api-key, plan, application and subscription into the execution context.
-                        ctx.setAttribute(ContextAttributes.ATTR_APPLICATION, apiKey.getApplication());
-                        ctx.setAttribute(ContextAttributes.ATTR_SUBSCRIPTION_ID, apiKey.getSubscription());
-                        ctx.setAttribute(ContextAttributes.ATTR_PLAN, apiKey.getPlan());
-                        ctx.setAttribute(ATTR_API_KEY, apiKey.getKey());
-
-                        if (isApiKeyValid(ctx, apiKey)) {
-                            return Completable.complete();
-                        }
+                    if (this.handleApiKey(apiKeyOpt, ctx, (apiKey -> true))) {
+                        return Completable.complete();
                     }
                 } catch (Throwable t) {
                     log.warn("An exception occurred when trying to verify apikey.", t);
@@ -142,8 +144,8 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy {
             .doOnTerminate(() -> cleanupApiKey(ctx));
     }
 
-    private boolean isApiKeyValid(HttpPlainExecutionContext ctx, ApiKey apiKey) {
-        return !apiKey.isRevoked() && (apiKey.getExpireAt() == null || apiKey.getExpireAt().after(new Date(ctx.request().timestamp())));
+    private boolean isApiKeyValid(BaseExecutionContext ctx, ApiKey apiKey) {
+        return !apiKey.isRevoked() && (apiKey.getExpireAt() == null || apiKey.getExpireAt().after(new Date(ctx.timestamp())));
     }
 
     private Completable interrupt401(HttpPlainExecutionContext ctx, String key) {
@@ -186,5 +188,99 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy {
             ctx.request().parameters().remove(API_KEY_QUERY_PARAMETER);
         }
         ctx.removeInternalAttribute(ATTR_INTERNAL_API_KEY);
+    }
+
+    @Override
+    public Maybe<SecurityToken> extractSecurityToken(KafkaConnectionContext ctx) {
+        Callback[] callbacks = ctx.callbacks();
+        for (Callback callback : callbacks) {
+            if (callback instanceof NameCallback nameCallback) {
+                // With SASL_PLAIN or SCRAM, we expect the username to be a md5 hash of the api-key, for security and privacy.
+                String md5ApiKey = nameCallback.getName();
+                if (md5ApiKey != null && !md5ApiKey.isBlank()) {
+                    ctx.setInternalAttribute(ATTR_INTERNAL_MD5_API_KEY, md5ApiKey);
+                    return Maybe.just(SecurityToken.forMD5ApiKey(md5ApiKey));
+                }
+                return Maybe.just(SecurityToken.invalid(MD5_API_KEY));
+            }
+        }
+        return Maybe.empty();
+    }
+
+    @Override
+    public Completable authenticate(KafkaConnectionContext ctx) {
+        return Completable
+            .defer(() -> {
+                String md5ApiKey = ctx.getInternalAttribute(ATTR_INTERNAL_MD5_API_KEY);
+                final Optional<ApiKey> apiKeyOpt = ctx
+                    .getComponent(ApiKeyService.class)
+                    .getByApiAndMd5Key(ctx.getAttribute(ContextAttributes.ATTR_API), md5ApiKey);
+
+                if (
+                    this.handleApiKey(
+                            apiKeyOpt,
+                            ctx,
+                            apiKey -> {
+                                Callback[] callbacks = ctx.callbacks();
+                                for (Callback callback : callbacks) {
+                                    if (callback instanceof PlainAuthenticateCallback plainAuthenticateCallback) {
+                                        plainAuthenticateCallback.authenticated(true);
+                                        return true;
+                                    } else if (callback instanceof ScramCredentialCallback scramCredentialCallback) {
+                                        ScramCredential scramCredential = createScramCredential(
+                                            apiKey.getKey(),
+                                            ScramMechanism.forMechanismName(ctx.saslMechanism())
+                                        );
+                                        scramCredentialCallback.scramCredential(scramCredential);
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            }
+                        )
+                ) {
+                    return Completable.complete();
+                }
+                return Completable.error(new Exception(API_KEY_INVALID_KEY));
+            })
+            .doOnTerminate(() -> cleanupApiKey(ctx));
+    }
+
+    private void cleanupApiKey(KafkaConnectionContext ctx) {
+        ctx.removeInternalAttribute(ATTR_INTERNAL_MD5_API_KEY);
+    }
+
+    @SneakyThrows
+    private ScramCredential createScramCredential(String password, ScramMechanism mechanism) {
+        // Number of iterations for PBKDF2
+        int iterations = 4096;
+
+        // Generate a random salt (typically 16 bytes)
+        byte[] salt = new byte[25];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(salt);
+
+        // ScramFormatter helps derive the storedKey and serverKey
+        ScramFormatter formatter = new ScramFormatter(mechanism);
+
+        // Generate storedKey and serverKey using the formatter
+        return formatter.generateCredential(salt, formatter.saltedPassword(password, salt, iterations), iterations);
+    }
+
+    private boolean handleApiKey(Optional<ApiKey> apiKeyOpt, BaseExecutionContext ctx, Function<ApiKey, Boolean> handleIfApiKeyIsValid) {
+        if (apiKeyOpt.isPresent()) {
+            ApiKey apiKey = apiKeyOpt.get();
+
+            // Add data about api-key, plan, application and subscription into the execution context.
+            ctx.setAttribute(ContextAttributes.ATTR_APPLICATION, apiKey.getApplication());
+            ctx.setAttribute(ContextAttributes.ATTR_SUBSCRIPTION_ID, apiKey.getSubscription());
+            ctx.setAttribute(ContextAttributes.ATTR_PLAN, apiKey.getPlan());
+            ctx.setAttribute(ATTR_API_KEY, apiKey.getKey());
+
+            if (isApiKeyValid(ctx, apiKey)) {
+                return handleIfApiKeyIsValid.apply(apiKey);
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7143

**Description**

- implements native kafka security methods
- use new HttpSecurityPolicy interface

BREAKING CHANGE: requires APIM 4.6+
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-apim-7143-impl-security-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/5.0.0-apim-7143-impl-security-chain-SNAPSHOT/gravitee-policy-apikey-5.0.0-apim-7143-impl-security-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
