### PR TITLE
Fix extracted token from callback

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -197,11 +197,15 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy, 
             if (callback instanceof NameCallback nameCallback) {
                 // With SASL_PLAIN or SCRAM, we expect the username to be a md5 hash of the api-key, for security and privacy.
                 String md5ApiKey = nameCallback.getName();
-                if (md5ApiKey != null && !md5ApiKey.isBlank()) {
-                    ctx.setInternalAttribute(ATTR_INTERNAL_MD5_API_KEY, md5ApiKey);
-                    return Maybe.just(SecurityToken.forMD5ApiKey(md5ApiKey));
+                if (md5ApiKey == null || md5ApiKey.isBlank()) {
+                    md5ApiKey = nameCallback.getDefaultName();
                 }
-                return Maybe.just(SecurityToken.invalid(MD5_API_KEY));
+                if (md5ApiKey == null || md5ApiKey.isBlank()) {
+                    return Maybe.just(SecurityToken.invalid(MD5_API_KEY));
+                }
+
+                ctx.setInternalAttribute(ATTR_INTERNAL_MD5_API_KEY, md5ApiKey);
+                return Maybe.just(SecurityToken.forMD5ApiKey(md5ApiKey));
             }
         }
         return Maybe.empty();

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -532,8 +532,23 @@ public class ApiKeyPolicyTest {
 
         @Test
         void extractSecurityToken_shouldReturnSecurityToken_whenCallbackHasName() {
-            NameCallback nameCallback = new NameCallback("prompt");
+            NameCallback nameCallback = new NameCallback("prompt", "default name");
             nameCallback.setName(API_KEY);
+
+            when(ctx.callbacks()).thenReturn(new Callback[] { nameCallback });
+
+            final ApiKeyPolicy cut = new ApiKeyPolicy(configuration);
+            final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+            obs.assertValue(token ->
+                token.getTokenType().equals(SecurityToken.TokenType.MD5_API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+            );
+            verify(ctx).setInternalAttribute(ATTR_INTERNAL_MD5_API_KEY, API_KEY);
+        }
+
+        @Test
+        void extractSecurityToken_shouldReturnSecurityToken_whenCallbackHasDefaultName() {
+            NameCallback nameCallback = new NameCallback("prompt", API_KEY);
 
             when(ctx.callbacks()).thenReturn(new Callback[] { nameCallback });
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

`name` in `NameCallback` can be null. Fallback on `defaultName`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-fix-extract-token-from-callback-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/5.0.0-fix-extract-token-from-callback-SNAPSHOT/gravitee-policy-apikey-5.0.0-fix-extract-token-from-callback-SNAPSHOT.zip)
  <!-- Version placeholder end -->
