### PR TITLE
fix(native kafka): handle wrong password in sasl plain authent

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -228,8 +228,10 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy, 
                                 Callback[] callbacks = ctx.callbacks();
                                 for (Callback callback : callbacks) {
                                     if (callback instanceof PlainAuthenticateCallback plainAuthenticateCallback) {
-                                        plainAuthenticateCallback.authenticated(true);
-                                        return true;
+                                        if (String.valueOf(plainAuthenticateCallback.password()).equals(apiKey.getKey())) {
+                                            plainAuthenticateCallback.authenticated(true);
+                                            return true;
+                                        }
                                     } else if (callback instanceof ScramCredentialCallback scramCredentialCallback) {
                                         ScramCredential scramCredential = createScramCredential(
                                             apiKey.getKey(),


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8196

**Description**

When using SASL_PLAIN, the password field should contain the apikey and the username the md5 version of the apikey.
This PR add a test to check if the password is correct.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-apim-8196-handle-wrong-password-in-sasl-plain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/5.0.1-apim-8196-handle-wrong-password-in-sasl-plain-SNAPSHOT/gravitee-policy-apikey-5.0.1-apim-8196-handle-wrong-password-in-sasl-plain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
