### PR TITLE
support Authorization Bearer as a token source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,13 @@
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- vaadin/android-json is an outdated org.json fork that shadows the modern one (missing JSONObject.keySet()) and breaks everit-json-schema. -->
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,11 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>24.0.0-alpha.3</version>
+        <version>24.0.2</version>
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.11.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.11.0</gravitee-apim.version>
 
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>
 

--- a/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
+++ b/src/main/java/io/gravitee/policy/apikey/ApiKeyPolicy.java
@@ -33,12 +33,12 @@ import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.api.policy.http.HttpSecurityPolicy;
 import io.gravitee.gateway.reactive.api.policy.kafka.KafkaSecurityPolicy;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.apikey.configuration.ApiKeySource;
 import io.gravitee.policy.v3.apikey.ApiKeyPolicyV3;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.security.SecureRandom;
 import java.util.Date;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.security.auth.callback.Callback;
@@ -50,6 +50,7 @@ import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.scram.ScramCredentialCallback;
 import org.apache.kafka.common.security.scram.internals.ScramFormatter;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.DigestUtils;
 import org.springframework.util.StringUtils;
 
@@ -67,10 +68,14 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy, 
     static final String API_KEY_QUERY_PARAMETER_PROPERTY = "policy.api-key.param";
     static final String DEFAULT_API_KEY_QUERY_PARAMETER = "api-key";
     static final String DEFAULT_API_KEY_HEADER_PARAMETER = GraviteeHttpHeader.X_GRAVITEE_API_KEY;
+    static final String AUTHORIZATION_HEADER = "Authorization";
+    static final String BEARER_PREFIX = "Bearer ";
+
+    @Nullable
     static String API_KEY_HEADER, API_KEY_QUERY_PARAMETER;
 
-    public ApiKeyPolicy(ApiKeyPolicyConfiguration configuration) {
-        super(configuration);
+    public ApiKeyPolicy(@Nullable ApiKeyPolicyConfiguration configuration) {
+        super(configuration != null ? configuration : ApiKeyPolicyConfiguration.DEFAULT);
     }
 
     @Override
@@ -152,52 +157,73 @@ public class ApiKeyPolicy extends ApiKeyPolicyV3 implements HttpSecurityPolicy, 
     }
 
     private Optional<String> extractApiKey(HttpPlainExecutionContext ctx) {
-        // 1_ First, check if already resolved.
         String apiKey = ctx.getInternalAttribute(ATTR_INTERNAL_API_KEY);
         if (apiKey != null) {
             return Optional.of(apiKey);
         }
 
         final HttpPlainRequest request = ctx.request();
+        final ApiKeySource source = apiKeyPolicyConfiguration.resolveSource();
 
-        // If a custom header is defined in the policy configuration, use it exclusively.
-        if (
-            apiKeyPolicyConfiguration != null &&
-            apiKeyPolicyConfiguration.isEnableCustomApiKeyHeader() &&
-            StringUtils.hasText(apiKeyPolicyConfiguration.getApiKeyHeader())
-        ) {
-            final String apiKeyHeaderName = apiKeyPolicyConfiguration.getApiKeyHeader();
-            if (request.headers().contains(apiKeyHeaderName)) {
-                apiKey = request.headers().get(apiKeyHeaderName);
-                // Header is present but empty so init apiKey with empty string
-                return Optional.of(Objects.requireNonNullElse(apiKey, ""));
-            }
+        return switch (source) {
+            case HEADER -> extractFromHeader(request, resolveHeaderNameOrDefault()).or(() ->
+                extractFromQueryParam(request, API_KEY_QUERY_PARAMETER)
+            );
+            case BEARER -> extractFromBearer(request);
+            case QUERY_PARAMETER -> extractFromQueryParam(request, API_KEY_QUERY_PARAMETER);
+        };
+    }
+
+    private String resolveHeaderNameOrDefault() {
+        return apiKeyPolicyConfiguration
+            .resolveHeaderName() // policy config
+            .or(() -> Optional.ofNullable(API_KEY_HEADER)) // gravitee.yaml config
+            .orElse(GraviteeHttpHeader.X_GRAVITEE_API_KEY); // default
+    }
+
+    private static Optional<String> extractFromHeader(HttpPlainRequest request, String headerName) {
+        if (!StringUtils.hasText(headerName) || !request.headers().contains(headerName)) {
             return Optional.empty();
         }
+        return Optional.ofNullable(request.headers().get(headerName));
+    }
 
-        // 2_ Second, search in HTTP headers
-        if (request.headers().contains(API_KEY_HEADER)) {
-            apiKey = request.headers().get(API_KEY_HEADER);
-            // Header is present but empty so init apiKey with empty string
-            return Optional.of(Objects.requireNonNullElse(apiKey, ""));
+    private static Optional<String> extractFromQueryParam(HttpPlainRequest request, @Nullable String paramName) {
+        if (!StringUtils.hasText(paramName) || !request.parameters().containsKey(paramName)) {
+            return Optional.empty();
         }
+        return Optional.ofNullable(request.parameters().getFirst(paramName));
+    }
 
-        // 3_ If not found, search in query parameters
-        if (request.parameters().containsKey(API_KEY_QUERY_PARAMETER)) {
-            apiKey = request.parameters().getFirst(API_KEY_QUERY_PARAMETER);
-            // If query parameter is present but empty, init apiKey with empty string
-            return Optional.of(Objects.requireNonNullElse(apiKey, ""));
+    private static Optional<String> extractFromBearer(HttpPlainRequest request) {
+        if (!request.headers().contains(AUTHORIZATION_HEADER)) {
+            return Optional.empty();
         }
-
-        return Optional.empty();
+        final String authorization = request.headers().get(AUTHORIZATION_HEADER);
+        if (authorization == null || authorization.length() < BEARER_PREFIX.length()) {
+            return Optional.empty();
+        }
+        if (!authorization.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            return Optional.empty();
+        }
+        return Optional.of(authorization.substring(BEARER_PREFIX.length()).trim());
     }
 
     private void cleanupApiKey(HttpPlainExecutionContext ctx) {
-        if (apiKeyPolicyConfiguration == null || !apiKeyPolicyConfiguration.isPropagateApiKey()) {
-            ctx.request().headers().remove(API_KEY_HEADER);
-            ctx.request().parameters().remove(API_KEY_QUERY_PARAMETER);
-            if (apiKeyPolicyConfiguration != null && apiKeyPolicyConfiguration.getApiKeyHeader() != null) {
-                ctx.request().headers().remove(apiKeyPolicyConfiguration.getApiKeyHeader());
+        if (!apiKeyPolicyConfiguration.isPropagateApiKey()) {
+            switch (apiKeyPolicyConfiguration.resolveSource()) {
+                case BEARER -> ctx.request().headers().remove(AUTHORIZATION_HEADER);
+                case HEADER -> {
+                    ctx.request().headers().remove(resolveHeaderNameOrDefault());
+                    if (StringUtils.hasText(API_KEY_QUERY_PARAMETER)) {
+                        ctx.request().parameters().remove(API_KEY_QUERY_PARAMETER);
+                    }
+                }
+                case QUERY_PARAMETER -> {
+                    if (StringUtils.hasText(API_KEY_QUERY_PARAMETER)) {
+                        ctx.request().parameters().remove(API_KEY_QUERY_PARAMETER);
+                    }
+                }
             }
         }
         ctx.removeInternalAttribute(ATTR_INTERNAL_API_KEY);

--- a/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
@@ -15,9 +15,16 @@
  */
 package io.gravitee.policy.apikey.configuration;
 
+import io.gravitee.common.http.GraviteeHttpHeader;
 import io.gravitee.policy.api.PolicyConfiguration;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.StringUtils;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -25,11 +32,34 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ApiKeyPolicyConfiguration implements PolicyConfiguration {
 
     private boolean propagateApiKey = false;
 
+    @Nullable
+    private ApiKeySource source;
+
+    @Nullable
+    private String apiKeyHeader;
+
+    @Deprecated
     private boolean enableCustomApiKeyHeader = false;
 
-    private String apiKeyHeader;
+    public ApiKeySource resolveSource() {
+        return Objects.requireNonNullElse(source, ApiKeySource.HEADER);
+    }
+
+    /** Header name for HEADER source. Falls back to {@code X-Gravitee-Api-Key} when {@code apiKeyHeader} is blank. */
+    public Optional<String> resolveHeaderName() {
+        return StringUtils.hasText(apiKeyHeader) ? Optional.of(apiKeyHeader) : Optional.empty();
+    }
+
+    public static final ApiKeyPolicyConfiguration DEFAULT = new ApiKeyPolicyConfiguration(
+        false,
+        ApiKeySource.HEADER,
+        GraviteeHttpHeader.X_GRAVITEE_API_KEY,
+        false
+    );
 }

--- a/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeySource.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeySource.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.apikey.configuration;
+
+public enum ApiKeySource {
+    HEADER,
+    BEARER,
+    QUERY_PARAMETER,
+}

--- a/src/main/java/io/gravitee/policy/apikey/configuration/package-info.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package io.gravitee.policy.apikey.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/gravitee/policy/apikey/package-info.java
+++ b/src/main/java/io/gravitee/policy/apikey/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package io.gravitee.policy.apikey;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/apikey/ApiKeyPolicyV3.java
@@ -27,6 +27,8 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
 import java.util.*;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
@@ -45,6 +47,7 @@ public class ApiKeyPolicyV3 {
     /**
      * Policy configuration
      */
+    @NonNull
     protected final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration;
 
     static String API_KEY_HEADER, API_KEY_QUERY_PARAMETER;
@@ -52,8 +55,8 @@ public class ApiKeyPolicyV3 {
     static final String API_KEY_QUERY_PARAMETER_PROPERTY = "policy.api-key.param";
     static final String DEFAULT_API_KEY_QUERY_PARAMETER = "api-key";
 
-    public ApiKeyPolicyV3(ApiKeyPolicyConfiguration apiKeyPolicyConfiguration) {
-        this.apiKeyPolicyConfiguration = apiKeyPolicyConfiguration;
+    public ApiKeyPolicyV3(@Nullable ApiKeyPolicyConfiguration apiKeyPolicyConfiguration) {
+        this.apiKeyPolicyConfiguration = Objects.requireNonNullElse(apiKeyPolicyConfiguration, ApiKeyPolicyConfiguration.DEFAULT);
     }
 
     @OnRequest

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -6,20 +6,40 @@
             "title": "Propagate API Key to upstream API",
             "type": "boolean"
         },
+        "source": {
+            "type": "string",
+            "enum": ["HEADER", "BEARER", "QUERY_PARAMETER"],
+            "default": "HEADER",
+            "gioConfig": {
+                "enumLabelMap": {
+                    "HEADER": "Get API key in headers (with fallback on query parameter 'api-key')",
+                    "BEARER": "Get API key in authorization Bearer header (incompatible with APIv2 and OAuth)",
+                    "QUERY_PARAMETER": "Get API key in query parameter"
+                }
+            }
+        },
         "enableCustomApiKeyHeader": {
             "title": "Custom API Key header",
             "description": "Overrides the default API Key header",
-            "type": "boolean"
+            "type": "boolean",
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.source": "BAD_VALUE"
+                    }
+                }
+            }
         },
         "apiKeyHeader": {
             "title": "API Key Header",
-            "description": "Enter a custom header name to override the default value",
+            "description": "Enter a header name",
             "type": "string",
+            "default": "X-Gravitee-Api-Key",
             "pattern": "^[a-zA-Z0-9!#$%&'*+\\-.^`|~]+$",
             "gioConfig": {
-                "disableIf": {
+                "displayIf": {
                     "$eq": {
-                        "value.enableCustomApiKeyHeader": false
+                        "value.source": "HEADER"
                     }
                 }
             }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -46,6 +46,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.NameCallback;
 import org.apache.kafka.common.security.plain.PlainAuthenticateCallback;
 import org.apache.kafka.common.security.scram.ScramCredentialCallback;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -74,8 +75,7 @@ public class ApiKeyPolicyTest {
     protected static final Date EXPIRE_AT = new Date(System.currentTimeMillis() + 3600000);
     protected static final RuntimeException MOCK_EXCEPTION = new RuntimeException("Mock exception");
 
-    @Mock
-    private ApiKeyPolicyConfiguration configuration;
+    private final ApiKeyPolicyConfiguration configuration = new ApiKeyPolicyConfiguration();
 
     @Mock
     private ApiKeyService apiKeyService;
@@ -113,7 +113,7 @@ public class ApiKeyPolicyTest {
             final HttpHeaders headers = buildHttpHeaders(DEFAULT_API_KEY_HEADER_PARAMETER);
             final ApiKey apiKey = buildApiKey();
 
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(request.headers()).thenReturn(headers);
             mockApiKeyService(apiKey);
 
@@ -134,7 +134,7 @@ public class ApiKeyPolicyTest {
         void shouldCompleteWhenApiKeyAlreadyInContextInternalAttributes() {
             final ApiKey apiKey = buildApiKey();
 
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(ctx.getInternalAttribute(ATTR_INTERNAL_API_KEY)).thenReturn(API_KEY);
             mockApiKeyService(apiKey);
 
@@ -166,7 +166,7 @@ public class ApiKeyPolicyTest {
         void shouldCompleteAndRemoveApiKeyFromInternalAttributeWhenPropagateApiKeyIsDisabled() {
             final ApiKey apiKey = buildApiKey();
 
-            when(configuration.isPropagateApiKey()).thenReturn(false);
+            configuration.setPropagateApiKey(false);
             when(ctx.getInternalAttribute(ATTR_INTERNAL_API_KEY)).thenReturn(API_KEY);
             when(request.headers()).thenReturn(mock(HttpHeaders.class));
             when(request.parameters()).thenReturn(mock(MultiValueMap.class));
@@ -185,7 +185,7 @@ public class ApiKeyPolicyTest {
             final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY);
             final ApiKey apiKey = buildApiKey();
 
-            when(configuration.isPropagateApiKey()).thenReturn(false);
+            configuration.setPropagateApiKey(false);
             when(request.headers()).thenReturn(headers);
             when(request.parameters()).thenReturn(mock(MultiValueMap.class));
             mockApiKeyService(apiKey);
@@ -206,7 +206,7 @@ public class ApiKeyPolicyTest {
             final ApiKey apiKey = buildApiKey();
 
             initializeParamNames(customHeader, DEFAULT_API_KEY_QUERY_PARAMETER);
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(request.headers()).thenReturn(headers);
             mockApiKeyService(apiKey);
 
@@ -226,7 +226,7 @@ public class ApiKeyPolicyTest {
             final ApiKey apiKey = buildApiKey();
 
             initializeParamNames(customHeader, DEFAULT_API_KEY_QUERY_PARAMETER);
-            when(configuration.isPropagateApiKey()).thenReturn(false);
+            configuration.setPropagateApiKey(false);
             when(request.headers()).thenReturn(headers);
             when(request.parameters()).thenReturn(mock(MultiValueMap.class));
             mockApiKeyService(apiKey);
@@ -245,7 +245,7 @@ public class ApiKeyPolicyTest {
             final MultiValueMap<String, String> parameters = buildQueryParameters(DEFAULT_API_KEY_QUERY_PARAMETER);
 
             when(request.parameters()).thenReturn(parameters);
-            when(configuration.isPropagateApiKey()).thenReturn(false);
+            configuration.setPropagateApiKey(false);
             when(request.headers()).thenReturn(HttpHeaders.create());
             mockApiKeyService(apiKey);
 
@@ -265,7 +265,7 @@ public class ApiKeyPolicyTest {
 
             initializeParamNames(DEFAULT_API_KEY_HEADER_PARAMETER, customQueryParam);
             when(request.parameters()).thenReturn(parameters);
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(request.headers()).thenReturn(HttpHeaders.create());
             mockApiKeyService(apiKey);
 
@@ -285,7 +285,7 @@ public class ApiKeyPolicyTest {
 
             initializeParamNames(DEFAULT_API_KEY_HEADER_PARAMETER, customQueryParam);
             when(request.parameters()).thenReturn(parameters);
-            when(configuration.isPropagateApiKey()).thenReturn(false);
+            configuration.setPropagateApiKey(false);
             when(request.headers()).thenReturn(mock(HttpHeaders.class));
             mockApiKeyService(apiKey);
 
@@ -326,7 +326,7 @@ public class ApiKeyPolicyTest {
             final ApiKey apiKey = buildApiKey();
             apiKey.setExpireAt(new Date(System.currentTimeMillis() - 3600000));
 
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(ctx.getInternalAttribute(ATTR_INTERNAL_API_KEY)).thenReturn(API_KEY);
             mockApiKeyService(apiKey);
             when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
@@ -354,7 +354,7 @@ public class ApiKeyPolicyTest {
             final ApiKey apiKey = buildApiKey();
             apiKey.setRevoked(true);
 
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(ctx.getInternalAttribute(ATTR_INTERNAL_API_KEY)).thenReturn(API_KEY);
             mockApiKeyService(apiKey);
             when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
@@ -381,7 +381,7 @@ public class ApiKeyPolicyTest {
         void shouldInterruptWith401WhenApiKeyNotFound() {
             final HttpHeaders headers = buildHttpHeaders(DEFAULT_API_KEY_HEADER_PARAMETER);
 
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(request.headers()).thenReturn(headers);
             mockApiKeyService(null);
             when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
@@ -406,7 +406,7 @@ public class ApiKeyPolicyTest {
 
         @Test
         void shouldInterruptWith401WhenExceptionOccurred() {
-            when(configuration.isPropagateApiKey()).thenReturn(true);
+            configuration.setPropagateApiKey(true);
             when(request.headers()).thenThrow(MOCK_EXCEPTION);
             when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
 
@@ -506,7 +506,7 @@ public class ApiKeyPolicyTest {
             return parameters;
         }
 
-        private void mockApiKeyService(ApiKey apiKey) {
+        private void mockApiKeyService(@Nullable ApiKey apiKey) {
             when(ctx.getComponent(ApiKeyService.class)).thenReturn(apiKeyService);
             when(ctx.getAttribute(ATTR_API)).thenReturn(API_ID);
             when(apiKeyService.getByApiAndKey(API_ID, API_KEY)).thenReturn(Optional.ofNullable(apiKey));
@@ -527,9 +527,9 @@ public class ApiKeyPolicyTest {
             when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
             final ApiKey apiKey = buildApiKey();
             mockApiKeyService(apiKey);
-            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = mock(ApiKeyPolicyConfiguration.class);
-            when(apiKeyPolicyConfiguration.getApiKeyHeader()).thenReturn(customHeader);
-            when(apiKeyPolicyConfiguration.isEnableCustomApiKeyHeader()).thenReturn(true);
+            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = new ApiKeyPolicyConfiguration();
+            apiKeyPolicyConfiguration.setApiKeyHeader(customHeader);
+            apiKeyPolicyConfiguration.setEnableCustomApiKeyHeader(true);
             final ApiKeyPolicy cut = new ApiKeyPolicy(apiKeyPolicyConfiguration);
             final TestObserver<Void> obs = cut.onRequest(ctx).test();
 
@@ -554,8 +554,8 @@ public class ApiKeyPolicyTest {
             when(apiKeyService.getByApiAndKey(API_ID, "")).thenReturn(Optional.empty());
             when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
 
-            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = mock(ApiKeyPolicyConfiguration.class);
-            when(apiKeyPolicyConfiguration.getApiKeyHeader()).thenReturn(customHeader);
+            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = new ApiKeyPolicyConfiguration();
+            apiKeyPolicyConfiguration.setApiKeyHeader(customHeader);
             final ApiKeyPolicy cut = new ApiKeyPolicy(apiKeyPolicyConfiguration);
             final TestObserver<Void> obs = cut.onRequest(ctx).test();
 
@@ -571,29 +571,27 @@ public class ApiKeyPolicyTest {
         }
 
         @Test
-        void shouldFailWhenCustomHeaderIsSetButDisabled() {
+        void shouldSucceedWhenCustomHeaderIsSetEvenIfToggleDisabled() {
+            // enableCustomApiKeyHeader is ignored at runtime: apiKeyHeader is always honored when set.
             final String customHeader = "X-Custom-Header";
             final HttpHeaders headers = HttpHeaders.create();
             headers.add(customHeader, API_KEY);
             when(request.headers()).thenReturn(headers);
             when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
-            when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
+            final ApiKey apiKey = buildApiKey();
+            mockApiKeyService(apiKey);
 
-            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = mock(ApiKeyPolicyConfiguration.class);
-            when(apiKeyPolicyConfiguration.getApiKeyHeader()).thenReturn(customHeader);
-            when(apiKeyPolicyConfiguration.isEnableCustomApiKeyHeader()).thenReturn(false);
+            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = new ApiKeyPolicyConfiguration();
+            apiKeyPolicyConfiguration.setApiKeyHeader(customHeader);
+            apiKeyPolicyConfiguration.setEnableCustomApiKeyHeader(false);
             final ApiKeyPolicy cut = new ApiKeyPolicy(apiKeyPolicyConfiguration);
             final TestObserver<Void> obs = cut.onRequest(ctx).test();
 
-            obs.assertFailure(Throwable.class);
+            obs.assertResult();
 
-            verify(ctx).interruptWith(
-                argThat(failure -> {
-                    assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
-                    assertEquals("API_KEY_MISSING", failure.key());
-                    return true;
-                })
-            );
+            verify(ctx).setAttribute(ContextAttributes.ATTR_APPLICATION, apiKey.getApplication());
+            verify(ctx).setAttribute(ATTR_API_KEY, apiKey.getKey());
+            verify(ctx, never()).interruptWith(any());
         }
 
         @Test
@@ -605,9 +603,9 @@ public class ApiKeyPolicyTest {
             when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
             final ApiKey apiKey = buildApiKey();
             mockApiKeyService(apiKey);
-            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = mock(ApiKeyPolicyConfiguration.class);
-            when(apiKeyPolicyConfiguration.getApiKeyHeader()).thenReturn(customHeader);
-            when(apiKeyPolicyConfiguration.isEnableCustomApiKeyHeader()).thenReturn(true);
+            final ApiKeyPolicyConfiguration apiKeyPolicyConfiguration = new ApiKeyPolicyConfiguration();
+            apiKeyPolicyConfiguration.setApiKeyHeader(customHeader);
+            apiKeyPolicyConfiguration.setEnableCustomApiKeyHeader(true);
             final ApiKeyPolicy cut = new ApiKeyPolicy(apiKeyPolicyConfiguration);
             final TestObserver<Void> obs = cut.onRequest(ctx).test();
 
@@ -633,8 +631,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -652,8 +651,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -669,8 +669,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -686,8 +687,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -703,8 +705,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -720,8 +723,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -737,8 +741,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -807,8 +812,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -827,8 +833,9 @@ public class ApiKeyPolicyTest {
                 cut
                     .extractSecurityToken(ctx)
                     .test()
-                    .assertValue(token ->
-                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    .assertValue(
+                        token ->
+                            token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
                     );
             }
 
@@ -1127,7 +1134,7 @@ public class ApiKeyPolicyTest {
             verify(ctx).setAttribute(ATTR_API_KEY, apiKey.getKey());
         }
 
-        private void mockApiKeyService(ApiKey apiKey) {
+        private void mockApiKeyService(@Nullable ApiKey apiKey) {
             when(ctx.getComponent(ApiKeyService.class)).thenReturn(apiKeyService);
             when(ctx.getAttribute(ATTR_API)).thenReturn(API_ID);
             when(apiKeyService.getByApiAndMd5Key(API_ID, API_KEY_MD5)).thenReturn(Optional.ofNullable(apiKey));

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -36,6 +36,7 @@ import io.gravitee.gateway.reactive.api.context.Response;
 import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.apikey.configuration.ApiKeySource;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.Date;
@@ -615,6 +616,255 @@ public class ApiKeyPolicyTest {
             verify(ctx).setAttribute(ContextAttributes.ATTR_APPLICATION, apiKey.getApplication());
             verify(ctx).setAttribute(ATTR_API_KEY, apiKey.getKey());
             verify(ctx, never()).interruptWith(any());
+        }
+
+        @Nested
+        class ExplicitSource {
+
+            @Test
+            void extractSecurityToken_shouldReturnSecurityToken_whenSourceIsHeader_default() {
+                final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.HEADER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnSecurityToken_whenSourceIsHeader_custom() {
+                final String customHeader = "X-My-Key";
+                final HttpHeaders headers = buildHttpHeaders(customHeader);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.HEADER);
+                config.setApiKeyHeader(customHeader);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnSecurityToken_whenSourceIsBearer() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Bearer " + API_KEY);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnSecurityToken_whenSourceIsQueryParameter() {
+                final MultiValueMap<String, String> parameters = buildQueryParameters(DEFAULT_API_KEY_QUERY_PARAMETER);
+                when(request.parameters()).thenReturn(parameters);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.QUERY_PARAMETER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldAcceptBearerSchemeInLowercase() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "bearer " + API_KEY);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldAcceptBearerSchemeInUppercase() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "BEARER " + API_KEY);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldTrimBearerToken() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Bearer   " + API_KEY + "  ");
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnEmpty_whenAuthorizationSchemeIsNotBearer() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Basic " + API_KEY);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut.extractSecurityToken(ctx).test().assertComplete().assertValueCount(0);
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnEmpty_whenBearerHasNoSeparatorSpace() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Bearer" + API_KEY);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut.extractSecurityToken(ctx).test().assertComplete().assertValueCount(0);
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnEmpty_whenAuthorizationHeaderAbsent() {
+                when(request.headers()).thenReturn(HttpHeaders.create());
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut.extractSecurityToken(ctx).test().assertComplete().assertValueCount(0);
+            }
+
+            @Test
+            void extractSecurityToken_shouldReturnInvalidToken_whenBearerTokenIsBlank() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Bearer    ");
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token -> token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.isInvalid());
+            }
+
+            @Test
+            void extractSecurityToken_shouldUseApiKeyHeaderEvenWhenEnableCustomApiKeyHeaderIsFalse() {
+                final String customHeader = "X-My-Key";
+                final HttpHeaders headers = buildHttpHeaders(customHeader);
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.HEADER);
+                config.setApiKeyHeader(customHeader);
+                config.setEnableCustomApiKeyHeader(false);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void extractSecurityToken_shouldPreferSourceOverLegacyFields() {
+                final HttpHeaders headers = HttpHeaders.create()
+                    .add("Authorization", "Bearer " + API_KEY)
+                    .add("X-Legacy-Header", "should-be-ignored");
+                when(request.headers()).thenReturn(headers);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                config.setApiKeyHeader("X-Legacy-Header");
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+
+                cut
+                    .extractSecurityToken(ctx)
+                    .test()
+                    .assertValue(token ->
+                        token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+                    );
+            }
+
+            @Test
+            void shouldRemoveAuthorizationHeader_whenSourceIsBearer_andPropagateDisabled() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Bearer " + API_KEY);
+                when(request.headers()).thenReturn(headers);
+                final ApiKey apiKey = buildApiKey();
+                mockApiKeyService(apiKey);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                config.setPropagateApiKey(false);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+                final TestObserver<Void> obs = cut.onRequest(ctx).test();
+
+                obs.assertResult();
+                assertFalse(headers.contains("Authorization"));
+            }
+
+            @Test
+            void shouldKeepAuthorizationHeader_whenSourceIsBearer_andPropagateEnabled() {
+                final HttpHeaders headers = HttpHeaders.create().add("Authorization", "Bearer " + API_KEY);
+                when(request.headers()).thenReturn(headers);
+                final ApiKey apiKey = buildApiKey();
+                mockApiKeyService(apiKey);
+
+                final ApiKeyPolicyConfiguration config = new ApiKeyPolicyConfiguration();
+                config.setSource(ApiKeySource.BEARER);
+                config.setPropagateApiKey(true);
+                final ApiKeyPolicy cut = new ApiKeyPolicy(config);
+                final TestObserver<Void> obs = cut.onRequest(ctx).test();
+
+                obs.assertResult();
+                assertTrue(headers.contains("Authorization"));
+            }
         }
     }
 

--- a/src/test/java/io/gravitee/policy/apikey/SchemaValidationTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/SchemaValidationTest.java
@@ -100,5 +100,68 @@ public class SchemaValidationTest {
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageContaining("#/apiKeyHeader: string [Invalid Header!] does not match pattern");
         }
+
+        @Test
+        void should_validate_configuration_with_source_header() throws JSONException {
+            String json = """
+                {
+                  "propagateApiKey": false,
+                  "source": "HEADER",
+                  "apiKeyHeader": "X-My-Key"
+                }
+                """;
+            String result = validator.validate(configurationSchema, json);
+            JSONAssert.assertEquals(json, result, true);
+        }
+
+        @Test
+        void should_validate_configuration_with_source_bearer() throws JSONException {
+            String json = """
+                {
+                  "propagateApiKey": true,
+                  "source": "BEARER"
+                }
+                """;
+            String result = validator.validate(configurationSchema, json);
+            JSONAssert.assertEquals(json, result, true);
+        }
+
+        @Test
+        void should_validate_configuration_with_source_query_parameter() throws JSONException {
+            String json = """
+                {
+                  "propagateApiKey": false,
+                  "source": "QUERY_PARAMETER"
+                }
+                """;
+            String result = validator.validate(configurationSchema, json);
+            JSONAssert.assertEquals(json, result, true);
+        }
+
+        @Test
+        void should_not_validate_invalid_source_value() {
+            String json = """
+                {
+                  "source": "NOT_A_VALID_SOURCE"
+                }
+                """;
+            assertThatThrownBy(() -> validator.validate(configurationSchema, json))
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessageContaining("#/source");
+        }
+
+        @Test
+        void should_validate_combined_legacy_and_new_fields() throws JSONException {
+            String json = """
+                {
+                  "propagateApiKey": false,
+                  "source": "BEARER",
+                  "enableCustomApiKeyHeader": true,
+                  "apiKeyHeader": "X-My-Key"
+                }
+                """;
+            String result = validator.validate(configurationSchema, json);
+            JSONAssert.assertEquals(json, result, true);
+        }
     }
 }

--- a/src/test/java/io/gravitee/policy/apikey/SchemaValidationTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/SchemaValidationTest.java
@@ -56,6 +56,7 @@ public class SchemaValidationTest {
                 """
                 {
                   "propagateApiKey": true,
+                  "source": "HEADER",
                   "enableCustomApiKeyHeader": true,
                   "apiKeyHeader": "X-My-Api-Key"
                 }
@@ -78,7 +79,9 @@ public class SchemaValidationTest {
                 """
                 {
                   "propagateApiKey": false,
-                  "enableCustomApiKeyHeader": false
+                  "source": "HEADER",
+                  "enableCustomApiKeyHeader": false,
+                  "apiKeyHeader": "X-Gravitee-Api-Key"
                 }
                 """,
                 result,
@@ -123,7 +126,17 @@ public class SchemaValidationTest {
                 }
                 """;
             String result = validator.validate(configurationSchema, json);
-            JSONAssert.assertEquals(json, result, true);
+            JSONAssert.assertEquals(
+                """
+                {
+                  "propagateApiKey": true,
+                  "source": "BEARER",
+                  "apiKeyHeader": "X-Gravitee-Api-Key"
+                }
+                """,
+                result,
+                true
+            );
         }
 
         @Test
@@ -135,7 +148,17 @@ public class SchemaValidationTest {
                 }
                 """;
             String result = validator.validate(configurationSchema, json);
-            JSONAssert.assertEquals(json, result, true);
+            JSONAssert.assertEquals(
+                """
+                {
+                  "propagateApiKey": false,
+                  "source": "QUERY_PARAMETER",
+                  "apiKeyHeader": "X-Gravitee-Api-Key"
+                }
+                """,
+                result,
+                true
+            );
         }
 
         @Test


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-XXXX

**Description**

Allow to use token as Authorization Bearer
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-mba-apikey-bearer-source-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/6.0.0-mba-apikey-bearer-source-SNAPSHOT/gravitee-policy-apikey-6.0.0-mba-apikey-bearer-source-SNAPSHOT.zip)
  <!-- Version placeholder end -->
