### PR TITLE
fix(apikey): restore custom API Key header toggle in console form

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
@@ -44,6 +44,11 @@ public class ApiKeyPolicyConfiguration implements PolicyConfiguration {
     @Nullable
     private String apiKeyHeader;
 
+    /**
+     * No longer required since 4.12.x: the custom {@link #apiKeyHeader} is always applied when set.
+     * Kept only for backward compatibility with gateways older than 4.12.x. To be removed once those
+     * versions are no longer supported.
+     */
     @Deprecated
     private boolean enableCustomApiKeyHeader = false;
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -13,19 +13,19 @@
             "gioConfig": {
                 "enumLabelMap": {
                     "HEADER": "Get API key in headers (with fallback on query parameter 'api-key')",
-                    "BEARER": "Get API key in authorization Bearer header (incompatible with APIv2 and OAuth)",
-                    "QUERY_PARAMETER": "Get API key in query parameter"
+                    "BEARER": "Get API key in authorization Bearer header (incompatible with APIv2 and OAuth). Requires a gateway 4.12.x or later.",
+                    "QUERY_PARAMETER": "Get API key in query parameter. Requires a gateway 4.12.x or later."
                 }
             }
         },
         "enableCustomApiKeyHeader": {
             "title": "Custom API Key header",
-            "description": "Overrides the default API Key header",
+            "description": "No longer required for gateways 4.12.x and later, where the name set in 'API Key Header' is always applied. Only enable it for gateways older than 4.12.x.",
             "type": "boolean",
             "gioConfig": {
                 "displayIf": {
                     "$eq": {
-                        "value.source": "BAD_VALUE"
+                        "value.source": "HEADER"
                     }
                 }
             }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14646
https://gravitee.atlassian.net/browse/APIM-14645
## Problem

The `enableCustomApiKeyHeader` toggle is hidden in the console because of a leftover placeholder `displayIf` condition introduced in #101:

```json
"displayIf": { "$eq": { "value.source": "BAD_VALUE" } }
```

`source` can only be `HEADER`, `BEARER` or `QUERY_PARAMETER` — never `BAD_VALUE` — so the toggle is **never rendered**.

Since 4.12.x the gateway always honors the custom `apiKeyHeader` when set, so the toggle is unnecessary on recent gateways. But **gateways older than 4.12.x still require `enableCustomApiKeyHeader: true`**, and with the toggle hidden they can no longer be configured through the console. This surfaced in a customer case: a custom header (`apikey`) returns 401 and the toggle can't be found in the UI.

## Changes

- `schema-form.json`: show the `enableCustomApiKeyHeader` toggle again when `source == HEADER` (consistent with the `apiKeyHeader` field).
- `schema-form.json`: update the toggle description to explain it's only needed for gateways older than 4.12.x.
- `schema-form.json`: note in the `BEARER` and `QUERY_PARAMETER` source labels that they require a gateway 4.12.x or later (the `source` field is ignored by older gateways).
- `ApiKeyPolicyConfiguration.java`: document the deprecated field and note it should be removed once pre-4.12.x gateways are no longer supported.

## Notes

- The exact APIM version bundling the "always honor apiKeyHeader" behavior should be confirmed (support thread states 4.12.0).
- Existing broken plans still need a one-time manual fix (re-enable the toggle + redeploy, or patch the plan config); this change only affects new edits.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.1-fix-custom-apikey-header-toggle-visibility-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/6.0.1-fix-custom-apikey-header-toggle-visibility-SNAPSHOT/gravitee-policy-apikey-6.0.1-fix-custom-apikey-header-toggle-visibility-SNAPSHOT.zip)
  <!-- Version placeholder end -->
