### PR TITLE
fix: stop hardcoding apiKeyHeader default

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
@@ -61,10 +61,13 @@ public class ApiKeyPolicyConfiguration implements PolicyConfiguration {
         return StringUtils.hasText(apiKeyHeader) ? Optional.of(apiKeyHeader) : Optional.empty();
     }
 
-    public static final ApiKeyPolicyConfiguration DEFAULT = new ApiKeyPolicyConfiguration(
-        false,
-        ApiKeySource.HEADER,
-        GraviteeHttpHeader.X_GRAVITEE_API_KEY,
-        false
-    );
+    /**
+     * {@code apiKeyHeader} is intentionally left {@code null} here: a {@code null} plan configuration means
+     * "no header explicitly configured on this plan", and must fall through to the gateway-wide
+     * {@code policy.api-key.header} setting the same way an explicit empty ({@code {}}) configuration does.
+     * Hardcoding {@link GraviteeHttpHeader#X_GRAVITEE_API_KEY} here made {@link #resolveHeaderName()} report a
+     * header as "configured" even when none was, which caused the gateway-wide header to be silently ignored
+     * for plans with no explicit security configuration (APIM-14651).
+     */
+    public static final ApiKeyPolicyConfiguration DEFAULT = new ApiKeyPolicyConfiguration(false, ApiKeySource.HEADER, null, false);
 }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -219,6 +219,28 @@ public class ApiKeyPolicyTest {
         }
 
         @Test
+        void shouldCompleteWhenNullConfigurationAndGlobalCustomHeaderConfigured() {
+            // APIM-14651: a plan with no explicit security configuration (null) must still honor the
+            // gateway-wide policy.api-key.header setting, exactly like a plan with an empty ("{}") configuration does.
+            final String globalCustomHeader = "X-Custom-Api-Key";
+            final HttpHeaders headers = buildHttpHeaders(globalCustomHeader);
+            final ApiKey apiKey = buildApiKey();
+
+            initializeParamNames(globalCustomHeader, DEFAULT_API_KEY_QUERY_PARAMETER);
+            when(request.headers()).thenReturn(headers);
+            when(request.parameters()).thenReturn(mock(MultiValueMap.class));
+            mockApiKeyService(apiKey);
+
+            final ApiKeyPolicy cut = new ApiKeyPolicy(null);
+            final TestObserver<Void> obs = cut.onRequest(ctx).test();
+
+            obs.assertResult();
+
+            verify(ctx).setAttribute(ContextAttributes.ATTR_APPLICATION, apiKey.getApplication());
+            verify(ctx, never()).interruptWith(any());
+        }
+
+        @Test
         void shouldCompleteAndRemoveApiKeyFromCustomHeaderWhenPropagateApiKeyIsDisabled() {
             final String customHeader = "My-Custom-Api-Key";
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14651

**Description**

A null apiKeyHeader must mean "not configured on this plan" so the gateway-wide header setting can apply. Hardcoding X-Gravitee-Api-Key in ApiKeyPolicyConfiguration.DEFAULT broke that contract for any plan without an explicit security configuration.

**Additional context**
## Test scenarios (APIM-14651)

### Automated
- `ApiKeyPolicyTest#shouldCompleteWhenNullConfigurationAndGlobalCustomHeaderConfigured` — a plan with `null` security configuration now correctly falls through to the gateway-wide `policy.api-key.header` setting instead of being shadowed by a hardcoded default.

### Manual verification (gateway, live API with 3 published API_KEY plans, no selection rules)

| # | Plan config | Gateway `policy.api-key.header` | Request header | Expected | Verifies |
|---|---|---|---|---|---|
| 1 | none (`apiKeyHeader` unset) | unset | `X-Gravitee-Api-Key` | 200 | Default behavior unchanged when nothing is customized |
| 1b | none | unset | `X-Custom-Api-Key` | 401 | No unintended fallback when no custom header is configured anywhere |
| 2 | none | `X-Custom-Api-Key` | `X-Custom-Api-Key` | 200 | **Core fix** — gateway-wide header now honored for plans with no explicit config |
| 2b | none | `X-Custom-Api-Key` | `X-Gravitee-Api-Key` | 401 | Old default is correctly rejected once gateway-wide override is active — proves it isn't silently ignored (the original bug) |
