### PR TITLE
fix: stop hardcoding apiKeyHeader default

### DIFF
--- a/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/apikey/configuration/ApiKeyPolicyConfiguration.java
@@ -56,15 +56,22 @@ public class ApiKeyPolicyConfiguration implements PolicyConfiguration {
         return Objects.requireNonNullElse(source, ApiKeySource.HEADER);
     }
 
-    /** Header name for HEADER source. Falls back to {@code X-Gravitee-Api-Key} when {@code apiKeyHeader} is blank. */
+    /**
+     * Header name explicitly configured on this plan for HEADER source, if any. Empty when
+     * {@code apiKeyHeader} is blank; callers (see {@code ApiKeyPolicy.resolveHeaderNameOrDefault()}) are
+     * responsible for falling through to the gateway-wide setting and then to {@code X-Gravitee-Api-Key}.
+     */
     public Optional<String> resolveHeaderName() {
         return StringUtils.hasText(apiKeyHeader) ? Optional.of(apiKeyHeader) : Optional.empty();
     }
 
-    public static final ApiKeyPolicyConfiguration DEFAULT = new ApiKeyPolicyConfiguration(
-        false,
-        ApiKeySource.HEADER,
-        GraviteeHttpHeader.X_GRAVITEE_API_KEY,
-        false
-    );
+    /**
+     * {@code apiKeyHeader} is intentionally left {@code null} here: a {@code null} plan configuration means
+     * "no header explicitly configured on this plan", and must fall through to the gateway-wide
+     * {@code policy.api-key.header} setting the same way an explicit empty ({@code {}}) configuration does.
+     * Hardcoding {@link GraviteeHttpHeader#X_GRAVITEE_API_KEY} here made {@link #resolveHeaderName()} report a
+     * header as "configured" even when none was, which caused the gateway-wide header to be silently ignored
+     * for plans with no explicit security configuration (APIM-14651).
+     */
+    public static final ApiKeyPolicyConfiguration DEFAULT = new ApiKeyPolicyConfiguration(false, ApiKeySource.HEADER, null, false);
 }

--- a/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/apikey/ApiKeyPolicyTest.java
@@ -219,6 +219,52 @@ public class ApiKeyPolicyTest {
         }
 
         @Test
+        void shouldCompleteWhenNullConfigurationAndGlobalCustomHeaderConfigured() {
+            // APIM-14651: a plan with no explicit security configuration (null) must still honor the
+            // gateway-wide policy.api-key.header setting, exactly like a plan with an empty ("{}") configuration does.
+            final String globalCustomHeader = "X-Custom-Api-Key";
+            final HttpHeaders headers = buildHttpHeaders(globalCustomHeader);
+            final ApiKey apiKey = buildApiKey();
+
+            initializeParamNames(globalCustomHeader, DEFAULT_API_KEY_QUERY_PARAMETER);
+            when(request.headers()).thenReturn(headers);
+            when(request.parameters()).thenReturn(mock(MultiValueMap.class));
+            mockApiKeyService(apiKey);
+
+            final ApiKeyPolicy cut = new ApiKeyPolicy(null);
+            final TestObserver<Void> obs = cut.onRequest(ctx).test();
+
+            obs.assertResult();
+
+            verify(ctx).setAttribute(ContextAttributes.ATTR_APPLICATION, apiKey.getApplication());
+            verify(ctx, never()).interruptWith(any());
+        }
+
+        @Test
+        void shouldInterruptWith401WhenGlobalCustomHeaderConfiguredButDefaultHeaderUsed() {
+            final String globalCustomHeader = "X-Custom-Api-Key";
+            final HttpHeaders headers = buildHttpHeaders(X_GRAVITEE_API_KEY);
+
+            initializeParamNames(globalCustomHeader, DEFAULT_API_KEY_QUERY_PARAMETER);
+            when(request.headers()).thenReturn(headers);
+            when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
+            when(ctx.interruptWith(any())).thenReturn(Completable.error(MOCK_EXCEPTION));
+
+            final ApiKeyPolicy cut = new ApiKeyPolicy(null);
+            final TestObserver<Void> obs = cut.onRequest(ctx).test();
+
+            obs.assertFailure(Throwable.class);
+
+            verify(ctx).interruptWith(
+                argThat(failure -> {
+                    assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
+                    assertEquals("API_KEY_MISSING", failure.key());
+                    return true;
+                })
+            );
+        }
+
+        @Test
         void shouldCompleteAndRemoveApiKeyFromCustomHeaderWhenPropagateApiKeyIsDisabled() {
             final String customHeader = "My-Custom-Api-Key";
 
@@ -446,6 +492,25 @@ public class ApiKeyPolicyTest {
             when(request.headers()).thenReturn(headers);
 
             final ApiKeyPolicy cut = new ApiKeyPolicy(configuration);
+            final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+            obs.assertValue(
+                token -> token.getTokenType().equals(SecurityToken.TokenType.API_KEY.name()) && token.getTokenValue().equals(API_KEY)
+            );
+        }
+
+        @Test
+        void extractSecurityToken_shouldReturnSecurityToken_whenNullConfigurationAndGlobalCustomHeaderConfigured() {
+            // APIM-14651: plan selection goes through extractSecurityToken(), which relies on the same
+            // resolveHeaderNameOrDefault() fallback chain as onRequest(). A plan with no explicit security
+            // configuration (null) must still resolve the api key via the gateway-wide custom header here too.
+            final String globalCustomHeader = "X-Custom-Api-Key";
+            final HttpHeaders headers = buildHttpHeaders(globalCustomHeader);
+
+            initializeParamNames(globalCustomHeader, DEFAULT_API_KEY_QUERY_PARAMETER);
+            when(request.headers()).thenReturn(headers);
+
+            final ApiKeyPolicy cut = new ApiKeyPolicy(null);
             final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
             obs.assertValue(


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14651

**Description**

A null apiKeyHeader must mean "not configured on this plan" so the gateway-wide header setting can apply. Hardcoding X-Gravitee-Api-Key in ApiKeyPolicyConfiguration.DEFAULT broke that contract for any plan without an explicit security configuration.

**Additional context**
## Test scenarios (APIM-14651)

### Automated
- `ApiKeyPolicyTest#shouldCompleteWhenNullConfigurationAndGlobalCustomHeaderConfigured` — a plan with `null` security configuration now correctly falls through to the gateway-wide `policy.api-key.header` setting instead of being shadowed by a hardcoded default.

### Manual verification (gateway, live API with 3 published API_KEY plans, no selection rules)

| # | Plan config | Gateway `policy.api-key.header` | Request header | Expected | Verifies |
|---|---|---|---|---|---|
| 1 | none (`apiKeyHeader` unset) | unset | `X-Gravitee-Api-Key` | 200 | Default behavior unchanged when nothing is customized |
| 1b | none | unset | `X-Custom-Api-Key` | 401 | No unintended fallback when no custom header is configured anywhere |
| 2 | none | `X-Custom-Api-Key` | `X-Custom-Api-Key` | 200 | **Core fix** — gateway-wide header now honored for plans with no explicit config |
| 2b | none | `X-Custom-Api-Key` | `X-Gravitee-Api-Key` | 401 | Old default is correctly rejected once gateway-wide override is active — proves it isn't silently ignored (the original bug) |
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.2-APIM-14651-api-key-header-fallback-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-apikey/6.0.2-APIM-14651-api-key-header-fallback-SNAPSHOT/gravitee-policy-apikey-6.0.2-APIM-14651-api-key-header-fallback-SNAPSHOT.zip)
  <!-- Version placeholder end -->
